### PR TITLE
Support Windows Codex injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Tilo 是给 Codex 桌面端用户准备的本地任务看板。它把散落在�
 - 把当前 Codex 对话变成一张任务卡片，随时回到原来的对话。
 - 用待办、进行中、待审核、已完成等状态整理工作，不再让重要事项沉下去。
 - 创建项目、搜索任务、设置优先级、置顶或归档卡片。
-- 把所有任务留在自己的 Mac 上，本地 SQLite 数据库保存，不依赖云端账号。
+- 把所有任务留在自己的电脑上，本地 SQLite 数据库保存，不依赖云端账号。
 
 ## 适合谁
 
@@ -19,7 +19,7 @@ Tilo 是给 Codex 桌面端用户准备的本地任务看板。它把散落在�
 
 ## 三步开始
 
-目前 Tilo 面向 macOS 和 Codex 桌面端。先准备好 Node.js 22.5 或更新版本，然后运行：
+Tilo 支持 macOS 和 Windows 版 Codex 桌面端。先准备好 Node.js 22.5 或更新版本，然后运行：
 
 ```bash
 git clone https://github.com/Ericwong5021/tilo.git
@@ -29,6 +29,10 @@ npm run build
 npm link
 tilo inject --launch
 ```
+
+Windows 用户需要安装 Microsoft Store 版 Codex。首次注入前请完全退出 Codex（包括后台进程），再执行 `tilo inject --launch`；Tilo 会通过应用标识冷启动 Codex，并在启动参数中启用本地调试端口。
+
+macOS 用户可以直接执行同一条命令。后台服务的 `tilo service` 命令目前仅用于 macOS；Windows 上 `tilo inject --launch` 会按需启动本地 Gateway 和注入守护进程。
 
 回到 Codex 桌面端，侧边栏会出现 Tilo。打开它，创建第一个项目和任务卡片即可。
 
@@ -53,7 +57,7 @@ tilo status
 tilo eject
 ```
 
-这不会删除你的任务数据。数据默认保存在 `~/.tilo/tilo.db`。
+这不会删除你的任务数据。数据默认保存在 `~/.tilo/tilo.db`；Windows 对应路径为 `%USERPROFILE%\.tilo\tilo.db`。
 
 ## 开源与隐私
 

--- a/src/cdp.ts
+++ b/src/cdp.ts
@@ -1,6 +1,6 @@
-import { spawn } from "node:child_process";
+import { execFileSync, spawn } from "node:child_process";
 import { port as gatewayPort } from "./config.js";
-import { injectionScript } from "./dom.js";
+import { injectionScript, injectionVersion } from "./dom.js";
 
 type Target = {
   id: string;
@@ -92,16 +92,95 @@ async function mainTargets(port: number) {
   return selected.length > 0 ? selected : candidates.slice(0, 1);
 }
 
+function windowsActivationScript(port: number) {
+  return `$ErrorActionPreference = "Stop"
+$ProgressPreference = "SilentlyContinue"
+try {
+$runningMainProcess = Get-CimInstance Win32_Process -Filter "Name = 'ChatGPT.exe'" |
+  Where-Object { $_.CommandLine -notmatch "--type=" } |
+  Select-Object -First 1
+if ($runningMainProcess) {
+  throw "Codex is already running without CDP. Quit Codex completely and try again."
+}
+
+$codexApp = Get-StartApps |
+  Where-Object { $_.AppID -like "OpenAI.Codex_*!App" } |
+  Select-Object -First 1
+if (-not $codexApp) {
+  throw "The Microsoft Store Codex application is not installed for this Windows user."
+}
+
+$activationSource = @'
+using System;
+using System.Runtime.InteropServices;
+
+[ComImport]
+[Guid("2e941141-7f97-4756-ba1d-9decde894a3d")]
+[InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+public interface IApplicationActivationManager {
+  [PreserveSig]
+  int ActivateApplication(
+    [MarshalAs(UnmanagedType.LPWStr)] string appUserModelId,
+    [MarshalAs(UnmanagedType.LPWStr)] string arguments,
+    uint options,
+    out uint processId);
+}
+
+[ComImport]
+[Guid("45BA127D-10A8-46EA-8AB7-56EA9078943C")]
+public class ApplicationActivationManager {}
+
+public static class TiloCodexApplication {
+  public static uint Activate(string appUserModelId, string arguments) {
+    var manager = (IApplicationActivationManager)new ApplicationActivationManager();
+    uint processId;
+    int result = manager.ActivateApplication(appUserModelId, arguments, 0, out processId);
+    Marshal.ThrowExceptionForHR(result);
+    return processId;
+  }
+}
+'@
+
+Add-Type -TypeDefinition $activationSource
+$arguments = "--remote-debugging-port=${port} --remote-allow-origins=http://127.0.0.1:${port}"
+[void][TiloCodexApplication]::Activate($codexApp.AppID, $arguments)
+} catch {
+  [Console]::Error.WriteLine($_.Exception.Message)
+  exit 1
+}
+`;
+}
+
 function launchCodex(port: number) {
-  const child = spawn("/usr/bin/open", [
-    "-n",
-    "-a",
-    "/Applications/ChatGPT.app",
-    "--args",
-    `--remote-debugging-port=${port}`,
-    `--remote-allow-origins=http://127.0.0.1:${port}`,
-  ], { detached: true, stdio: "ignore" });
-  child.unref();
+  if (process.platform === "darwin") {
+    const child = spawn("/usr/bin/open", [
+      "-n",
+      "-a",
+      "/Applications/ChatGPT.app",
+      "--args",
+      `--remote-debugging-port=${port}`,
+      `--remote-allow-origins=http://127.0.0.1:${port}`,
+    ], { detached: true, stdio: "ignore" });
+    child.unref();
+    return;
+  }
+  if (process.platform === "win32") {
+    const encoded = Buffer.from(windowsActivationScript(port), "utf16le").toString("base64");
+    try {
+      execFileSync("powershell.exe", ["-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-OutputFormat", "Text", "-EncodedCommand", encoded], {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"],
+        windowsHide: true,
+      });
+    } catch (error) {
+      const output = error && typeof error === "object"
+        ? String("stderr" in error ? error.stderr : "stdout" in error ? error.stdout : "").trim()
+        : "";
+      throw new Error(output || "codex_windows_launch_failed");
+    }
+    return;
+  }
+  throw new Error(`codex_launch_unsupported_${process.platform}`);
 }
 
 async function waitForTargets(port: number) {
@@ -124,7 +203,7 @@ async function installTarget(target: Target, port: number, accessToken: string) 
     await connection.send("Page.setBypassCSP", { enabled: true });
     await connection.send("Runtime.enable");
     const existing = await evaluate(connection, "window.__tiloInjection__?.version || null");
-    if (existing === "0.1.0") {
+    if (existing === injectionVersion) {
       const storedIdentifier = await evaluate(connection, "window.__tiloNewDocumentScriptId || null");
       await evaluate(connection, "window.__tiloInjection__.refresh()");
       return { targetId: target.id, title: target.title, installed: true, reused: true, identifier: typeof storedIdentifier === "string" ? storedIdentifier : undefined };
@@ -253,7 +332,7 @@ export async function watchInjection(port: number, accessToken: string) {
         await connection.send("Runtime.enable");
         const existing = await evaluate(connection, "window.__tiloInjection__?.version || null");
         let identifier: string | undefined;
-        if (existing === "0.1.0") {
+        if (existing === injectionVersion) {
           const stored = await evaluate(connection, "window.__tiloNewDocumentScriptId || null");
           identifier = typeof stored === "string" ? stored : undefined;
           await evaluate(connection, "window.__tiloInjection__.refresh()");

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -1,3 +1,5 @@
+export const injectionVersion = "0.1.1";
+
 export function injectionScript(port: number, accessToken: string, action: "install" | "uninstall") {
   if (action === "uninstall") {
     return `(() => {
@@ -14,7 +16,7 @@ export function injectionScript(port: number, accessToken: string, action: "inst
   const token = JSON.stringify(accessToken);
   return `(() => {
     "use strict";
-    const VERSION = "0.1.0";
+    const VERSION = ${JSON.stringify(injectionVersion)};
     const previous = window.__tiloInjection__;
     if (previous?.version === VERSION) {
       previous.refresh();
@@ -54,30 +56,30 @@ export function injectionScript(port: number, accessToken: string, action: "inst
       style.id = STYLE_ID;
       style.setAttribute(OWNED, "true");
       style.textContent = \`
-        #\${ENTRY_ID}[aria-current="page"] { background: var(--color-token-list-hover-background, color-mix(in srgb, currentColor 8%, transparent)); }
+        #\${ENTRY_ID}[aria-current="page"] { background: var(--color-background-primary-soft-active, var(--color-token-list-hover-background, color-mix(in srgb, currentColor 8%, transparent))); }
         [\${HOST}="true"] { position: relative !important; z-index: 31 !important; pointer-events: none !important; }
         [\${HIDDEN}="true"] { visibility: hidden !important; pointer-events: none !important; }
-        #\${PANEL_ID} { position: absolute; inset: 0; z-index: 2; display: flex; min-width: 0; min-height: 0; flex-direction: column; overflow: hidden; color: inherit; background: var(--color-token-bg-primary, Canvas); pointer-events: auto; }
+        #\${PANEL_ID} { position: absolute; inset: 0; z-index: 2; display: flex; min-width: 0; min-height: 0; flex-direction: column; overflow: hidden; color: var(--color-text-foreground, inherit); background: var(--color-background-surface, var(--wb-surface-primary, var(--color-token-bg-primary, Canvas))); pointer-events: auto; }
         #\${PANEL_ID}[hidden] { display: none !important; }
-        #\${PANEL_ID} .tilo-toolbar { display: flex; align-items: center; gap: 8px; min-height: 52px; padding: 0 16px; border-bottom: 1px solid var(--color-token-border-default, color-mix(in srgb, currentColor 14%, transparent)); }
+        #\${PANEL_ID} .tilo-toolbar { display: flex; align-items: center; gap: 8px; min-height: 52px; padding: 0 16px; border-bottom: 1px solid var(--color-border, var(--color-token-border-default, color-mix(in srgb, currentColor 14%, transparent))); background: var(--color-background-surface, var(--wb-surface-primary, transparent)); }
         #\${PANEL_ID} .tilo-title { margin-right: auto; font-size: 15px; font-weight: 600; }
-        #\${PANEL_ID} .tilo-control { min-height: 30px; border: 1px solid var(--color-token-border-default, color-mix(in srgb, currentColor 15%, transparent)); border-radius: 6px; color: inherit; background: transparent; padding: 0 8px; font: inherit; }
+        #\${PANEL_ID} .tilo-control { min-height: 30px; border: 1px solid var(--color-border, var(--color-token-border-default, color-mix(in srgb, currentColor 15%, transparent))); border-radius: 6px; color: inherit; background: var(--color-background-primary-soft, transparent); padding: 0 8px; font: inherit; }
         #\${PANEL_ID} .tilo-search { width: 180px; }
         #\${PANEL_ID} .tilo-board { display: grid; grid-auto-columns: minmax(220px, 1fr); grid-auto-flow: column; gap: 10px; min-height: 0; flex: 1; overflow: auto; padding: 12px; }
-        #\${PANEL_ID} .tilo-column { display: flex; min-height: 180px; flex-direction: column; gap: 7px; border-radius: 8px; background: color-mix(in srgb, currentColor 4%, transparent); padding: 8px; }
+        #\${PANEL_ID} .tilo-column { display: flex; min-height: 180px; flex-direction: column; gap: 7px; border-radius: 8px; background: var(--color-background-secondary-soft, color-mix(in srgb, currentColor 4%, transparent)); padding: 8px; }
         #\${PANEL_ID} .tilo-column-head { display: flex; align-items: center; justify-content: space-between; padding: 2px 3px 6px; font-size: 12px; font-weight: 600; }
-        #\${PANEL_ID} .tilo-card { border: 1px solid var(--color-token-border-default, color-mix(in srgb, currentColor 12%, transparent)); border-radius: 7px; background: var(--color-token-bg-primary, Canvas); padding: 9px; cursor: pointer; }
-        #\${PANEL_ID} .tilo-card:hover { background: var(--color-token-list-hover-background, color-mix(in srgb, currentColor 6%, transparent)); }
-        #\${PANEL_ID} .tilo-card-id { display: flex; justify-content: space-between; color: color-mix(in srgb, currentColor 55%, transparent); font-size: 11px; }
+        #\${PANEL_ID} .tilo-card { border: 1px solid var(--color-border, var(--color-token-border-default, color-mix(in srgb, currentColor 12%, transparent))); border-radius: 7px; background: var(--color-background-primary-soft, var(--color-token-bg-primary, Canvas)); padding: 9px; cursor: pointer; }
+        #\${PANEL_ID} .tilo-card:hover { background: var(--color-background-primary-ghost-hover, var(--color-token-list-hover-background, color-mix(in srgb, currentColor 6%, transparent))); }
+        #\${PANEL_ID} .tilo-card-id { display: flex; justify-content: space-between; color: var(--color-text-foreground-tertiary, color-mix(in srgb, currentColor 55%, transparent)); font-size: 11px; }
         #\${PANEL_ID} .tilo-card-title { margin: 6px 0 8px; font-size: 13px; line-height: 1.35; }
-        #\${PANEL_ID} .tilo-card-meta { display: flex; gap: 6px; color: color-mix(in srgb, currentColor 60%, transparent); font-size: 11px; }
+        #\${PANEL_ID} .tilo-card-meta { display: flex; gap: 6px; color: var(--color-text-foreground-secondary, color-mix(in srgb, currentColor 60%, transparent)); font-size: 11px; }
         #\${PANEL_ID} .tilo-link { margin-left: auto; }
-        #\${PANEL_ID} .tilo-empty { padding: 16px 4px; text-align: center; color: color-mix(in srgb, currentColor 45%, transparent); font-size: 12px; }
-        #tilo-dialog { width: min(560px, calc(100vw - 64px)); border: 1px solid var(--color-token-border-default, color-mix(in srgb, currentColor 15%, transparent)); border-radius: 10px; color: inherit; background: var(--color-token-bg-primary, Canvas); padding: 18px; }
+        #\${PANEL_ID} .tilo-empty { padding: 16px 4px; text-align: center; color: var(--color-text-foreground-tertiary, color-mix(in srgb, currentColor 45%, transparent)); font-size: 12px; }
+        #tilo-dialog { width: min(560px, calc(100vw - 64px)); border: 1px solid var(--color-border-strong, var(--color-border, var(--color-token-border-default, color-mix(in srgb, currentColor 15%, transparent)))); border-radius: 10px; color: var(--color-text-foreground, inherit); background: var(--color-background-surface, var(--wb-surface-primary, var(--color-token-bg-primary, Canvas))); padding: 18px; }
         #tilo-dialog::backdrop { background: rgba(0,0,0,.38); }
         #tilo-dialog form { display: grid; gap: 12px; }
         #tilo-dialog label { display: grid; gap: 5px; font-size: 12px; }
-        #tilo-dialog input, #tilo-dialog textarea, #tilo-dialog select { box-sizing: border-box; width: 100%; border: 1px solid var(--color-token-border-default, color-mix(in srgb, currentColor 15%, transparent)); border-radius: 6px; color: inherit; background: transparent; padding: 8px; font: inherit; }
+        #tilo-dialog input, #tilo-dialog textarea, #tilo-dialog select { box-sizing: border-box; width: 100%; border: 1px solid var(--color-border, var(--color-token-border-default, color-mix(in srgb, currentColor 15%, transparent))); border-radius: 6px; color: inherit; background: var(--color-background-primary-soft, transparent); padding: 8px; font: inherit; }
         #tilo-dialog textarea { min-height: 110px; resize: vertical; }
         #tilo-dialog .tilo-dialog-row { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; }
         #tilo-dialog .tilo-dialog-actions { display: flex; gap: 8px; justify-content: flex-end; }


### PR DESCRIPTION
## What

- Add Microsoft Store Codex cold-start support on Windows through the application activation API.
- Keep the existing macOS launch path and report unsupported platforms explicitly.
- Make the injected Tilo panel inherit Codex's native layered background, surface, text, hover, and border tokens.
- Document Windows installation and runtime behavior.

## Why

Tilo could only launch Codex on macOS, and its injected task board used legacy color tokens that did not match Codex's current regional theme surfaces.

## Impact

Windows users can install from source and run `tilo inject --launch` after fully quitting Codex. Embedded Tilo surfaces now update with Codex's native theme variables.

## Validation

- `npm run build`
- Live Windows CDP injection on port 9229
- Verified Tilo injection version 0.1.1 and sidebar entry
- Verified computed panel background `#1e1e1e`, text `#d4d4d4`, and native surface/border tokens
- Verified friendly active-process guard on Windows
- Ejected the test injection and stopped the temporary Gateway