### PR TITLE
Update README installation and feature copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,20 +29,6 @@
   <img src="assets/better-codex-board.png" width="1200" alt="Better Codex task board inside Codex Desktop" />
 </p>
 
-**Install in 30 seconds** — macOS:
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/Ericwong5021/better-codex/main/scripts/install.sh | bash
-```
-
-Windows (PowerShell):
-
-```powershell
-irm https://raw.githubusercontent.com/Ericwong5021/better-codex/main/scripts/install.ps1 | iex
-```
-
-Restart Codex from the Better Codex launcher, and the board is in your sidebar. Uninstall anytime with `better-codex eject` — your task data stays.
-
 ## Why this exists
 
 If you use Codex heavily, some of this probably sounds familiar:
@@ -60,11 +46,11 @@ Better Codex extends the native Codex Desktop app. Everything lives *inside* Cod
 
 **Lost sessions → tasks linked to conversations.** Capture any conversation as a task on a board, organized by project, status, priority, label, and owner. When you come back three days later, you don't scroll through chat history — you open the task and land in the exact linked thread, context intact.
 
-**One global config → per-Agent profiles.** Create a profile for each kind of work: a code reviewer with high reasoning, a frontend builder with its own instructions, a quick-answer assistant on a faster model. Each profile keeps its own model, reasoning level, instructions, and avatar. Changing one never touches the others, and new sessions stop inheriting whatever you tweaked last.
-
 **Ideas with nowhere to go → a real backlog.** Thought of something mid-conversation? Add it to the board in seconds and get back to what you were doing. It'll be there tomorrow, with a status and an owner, instead of dissolving into your chat history.
 
 **Chat-shaped work → a visible work loop.** Assign tasks to yourself or to an Agent. Run them manually, or let automatic mode pick up ready tasks and work through them. When something needs your review, a decision, or unblocking, it comes back to you — on the board, where you can see it.
+
+**Flexible Agent and model configuration.** You can create Agent profiles with dedicated instructions for different kinds of work: a high-reasoning code reviewer, a frontend engineer with dedicated instructions, or a quick-answer assistant running on a faster model. Each profile can have its own model, reasoning level, instructions, and avatar; or you can save a model configuration that works well for you and reuse it across tasks.
 
 <p align="center">
   <img src="assets/better-codex-agents.png" width="1200" alt="Reusable Agent profiles inside Better Codex" />
@@ -80,6 +66,22 @@ Better Codex extends the native Codex Desktop app. Everything lives *inside* Cod
 6. Open the task and continue in its linked Codex conversation.
 
 The same loop works for coding, research, writing, document prep — anything you already do in Codex.
+
+## Installation
+
+macOS:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/Ericwong5021/better-codex/main/scripts/install.sh | bash
+```
+
+Windows (PowerShell):
+
+```powershell
+irm https://raw.githubusercontent.com/Ericwong5021/better-codex/main/scripts/install.ps1 | iex
+```
+
+Restart Codex from the Better Codex launcher, and the board is in your sidebar. Uninstall anytime with `better-codex eject` — your task data stays.
 
 ## FAQ
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -29,26 +29,12 @@
   <img src="assets/better-codex-board.png" width="1200" alt="Codex Desktop 中的 Better Codex 任务看板" />
 </p>
 
-**30 秒装好** — macOS：
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/Ericwong5021/better-codex/main/scripts/install.sh | bash
-```
-
-Windows（PowerShell）：
-
-```powershell
-irm https://raw.githubusercontent.com/Ericwong5021/better-codex/main/scripts/install.ps1 | iex
-```
-
-从 Better Codex 启动入口重启 Codex，看板就在你的侧边栏里了。随时可以用 `better-codex eject` 卸载，任务数据会保留。
-
 ## 为什么会有这个项目
 
 如果你是 Codex 的重度用户，下面这些场景你多半不陌生：
 
-- **会话列表成了坟场。** 几十上百个对话堆在一起，标题大同小异，也没法按项目归类。想找回"上次调 auth 那个会话"，只能一边滚动一边靠猜。
-- **一份模型配置管着所有会话。** 为了一个复杂重构调高推理等级，之后每个新会话都跟着买单；为了快速问答换了个轻量模型，下次深度排查开局就先天不足。全局只有这一个旋钮，所有任务都在抢它。
+- **会话列表杂乱难找。** 几十上百个对话堆在一起，标题大同小异，也没法按项目归类。想找回"上次调 auth 那个会话"，只能一边滚动一边靠猜。
+- **所有会话共用一套模型配置。** 为了一个复杂重构调高推理等级，之后每个新会话都跟着买单；为了快速问答换了个轻量模型，下次深度排查开局就先天不足。全局只有这一个旋钮，所有任务都在抢它。
 - **想法没有地方放。** 聊着聊着又想到三件值得做的事，但 Codex 没有任何地方能记下它们——最后要么丢进备忘录，要么写成 TODO 注释，要么干脆忘了。那些"本来打算做的事"就这么悄悄蒸发了。
 - **Codex 长成了聊天的样子，但你的工作不是。** 真实的工作是一个跨越好几天、横跨好多会话的项目。Codex 只递给你一堆聊天记录，剩下的自求多福。
 
@@ -60,11 +46,11 @@ Better Codex 基于原生 Codex Desktop 二次开发。所有东西都在 Codex 
 
 **会话找不到 → 任务和会话双向关联。** 把任何对话一键收进看板，按项目、状态、优先级、标签和负责人组织起来。三天后回来，不用再翻聊天记录——打开任务卡片，直接落在关联的那个会话里，上下文原封不动。
 
-**全局配置互相打架 → 每个 Agent 一套配置。** 给每类工作建一个角色：高推理等级的代码审查员、带专属指令的前端工程师、跑在快速模型上的问答助手。每个角色的模型、推理等级、指令、头像都是独立的。改一个不影响其他，新会话也不再继承你上次随手调的参数。
-
 **想法没处放 → 一个真正的待办池。** 聊到一半想到新点子？几秒钟丢进看板，然后继续手头的事。明天它还在那儿，带着状态和负责人，而不是消失在聊天记录里。
 
 **聊天式工作 → 看得见的工作闭环。** 把任务分配给自己或某个 Agent。手动逐个启动，或者开启自动模式让就绪的任务依次跑起来。需要你审核、拍板或解除阻塞时，任务会回到你手上——就在看板上，一眼就能看到。
+
+**灵活配置 Agent 和模型。** 你可以为不同类型的工作创建带专属指令的 Agent 角色：高推理等级的代码审查员、带专属指令的前端工程师、运行在快速模型上的问答助手。每个角色的模型、推理等级、指令和头像都可以独立配置；或者你也可以保存一套自己顺手的模型配置，在不同任务之间快速复用。
 
 <p align="center">
   <img src="assets/better-codex-agents.png" width="1200" alt="Better Codex 中可复用的智能体配置" />
@@ -80,6 +66,22 @@ Better Codex 基于原生 Codex Desktop 二次开发。所有东西都在 Codex 
 6. 打开任务，回到关联的 Codex 对话继续工作。
 
 同一套流程可以用于编程、调研、写作、文档整理——所有你已经在 Codex 里做的事。
+
+## 安装方法
+
+macOS：
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/Ericwong5021/better-codex/main/scripts/install.sh | bash
+```
+
+Windows（PowerShell）：
+
+```powershell
+irm https://raw.githubusercontent.com/Ericwong5021/better-codex/main/scripts/install.ps1 | iex
+```
+
+从 Better Codex 启动入口重启 Codex，看板就在你的侧边栏里了。随时可以用 `better-codex eject` 卸载，任务数据会保留。
 
 ## 常见问题
 


### PR DESCRIPTION
## Summary

- Replace the 30-second installation claim with a standalone installation section.
- Refine Chinese and English README wording for sessions, model configuration, and Agent profiles.
- Place the Agent/model configuration copy next to the Agent screenshot.

## Validation

- Ran git diff --check on both README files.
- Confirmed the README-only commit excludes the existing image changes.