### PR TITLE
Block issue execution during enrichment

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -39,6 +39,7 @@ export type Project = {
 };
 
 export type PendingActor = "user" | "agent";
+export type EnrichmentStatus = "pending" | "failed" | null;
 
 export type Issue = {
   id: string;
@@ -59,6 +60,7 @@ export type Issue = {
   user_assigned: boolean;
   needs_attention: boolean;
   pending_actor: PendingActor;
+  enrichment_status: EnrichmentStatus;
   version: number;
   created_at: string;
   updated_at: string;
@@ -92,9 +94,10 @@ type IssueInput = {
   agentEnabled?: boolean;
   agentId?: string;
   userAssigned?: boolean;
+  enrichmentStatus?: EnrichmentStatus;
 };
 
-type IssuePatch = Partial<Pick<Issue, "project_id" | "title" | "description" | "status" | "priority" | "labels" | "sort_order" | "pinned" | "thread_id" | "workspace_path" | "agent_enabled" | "agent_id" | "user_assigned" | "needs_attention" | "pending_actor">>;
+type IssuePatch = Partial<Pick<Issue, "project_id" | "title" | "description" | "status" | "priority" | "labels" | "sort_order" | "pinned" | "thread_id" | "workspace_path" | "agent_enabled" | "agent_id" | "user_assigned" | "needs_attention" | "pending_actor" | "enrichment_status">>;
 
 type AgentProfileInput = Pick<AgentProfile, "name" | "description" | "instructions" | "model" | "reasoning_effort"> & { max_concurrency?: number };
 type AgentProfilePatch = Partial<AgentProfileInput>;
@@ -189,6 +192,7 @@ export class Store {
     this.ensureRunTable();
     this.ensureSettingsTable();
     this.ensureDispatchColumns();
+    this.ensureEnrichmentColumn();
     const integrity = this.db.prepare("PRAGMA quick_check").get() as Record<string, unknown> | undefined;
     if (String(integrity?.quick_check ?? "") !== "ok") {
       this.db.close();
@@ -312,6 +316,12 @@ export class Store {
     }
   }
 
+  private ensureEnrichmentColumn() {
+    const columns = new Set((this.db.prepare("PRAGMA table_info(issues)").all() as Array<{ name: string }>).map(item => item.name));
+    if (!columns.has("enrichment_status")) this.db.exec("ALTER TABLE issues ADD COLUMN enrichment_status TEXT");
+    this.db.exec("CREATE INDEX IF NOT EXISTS issues_enrichment_status ON issues(enrichment_status)");
+  }
+
   private ensureSettingsTable() {
     this.db.exec(`
       CREATE TABLE IF NOT EXISTS settings (
@@ -425,6 +435,8 @@ export class Store {
 
   isDispatchable(issue: Issue) {
     return Boolean(
+      issue.enrichment_status !== "pending"
+      &&
       issue.needs_attention
       && issue.pending_actor === "agent"
       && issue.agent_enabled
@@ -433,6 +445,14 @@ export class Store {
       && issue.status !== "done"
       && issue.status !== "cancelled",
     );
+  }
+
+  isEnrichmentPending(issue: Issue) {
+    return issue.enrichment_status === "pending";
+  }
+
+  listPendingEnrichmentIssues() {
+    return this.listIssues().filter(issue => issue.enrichment_status === "pending");
   }
 
   canAutoStartFromUserMessage(issue: Issue) {
@@ -628,14 +648,16 @@ export class Store {
   createIssue(input: IssueInput) {
     const project = this.getProject(input.projectId);
     if (!project) throw new Error("project_not_found");
-    const title = cleanTitle(input.title);
+    const enrichmentStatus = input.enrichmentStatus ?? null;
+    const title = enrichmentStatus === "pending" ? "正在理解任务" : cleanTitle(input.title);
     if (input.status && !issueStatuses.includes(input.status)) throw new Error("invalid_status");
     if (input.priority && !issuePriorities.includes(input.priority)) throw new Error("invalid_priority");
     const userAssigned = Boolean(input.userAssigned) && !Boolean(input.agentEnabled);
     const agentId = input.agentEnabled && input.agentId ? input.agentId : null;
     if (agentId && !this.getAgentProfile(agentId)) throw new Error("agent_not_found");
     const agentEnabled = Boolean(input.agentEnabled) && !userAssigned;
-    const status = input.status ?? "todo";
+    if (enrichmentStatus !== null && enrichmentStatus !== "pending" && enrichmentStatus !== "failed") throw new Error("invalid_enrichment_status");
+    const status = enrichmentStatus === "pending" ? "backlog" : input.status ?? "todo";
     const needsAttention = agentEnabled && status !== "backlog" && status !== "done" && status !== "cancelled" ? 1 : 0;
     const pendingActor = agentEnabled ? "agent" : "user";
     const id = randomUUID();
@@ -655,8 +677,8 @@ export class Store {
         INSERT INTO issues (
           id, identifier, project_id, title, description, status, priority, labels_json,
           sort_order, pinned, archived_at, thread_id, workspace_path, agent_enabled, agent_id, user_assigned,
-          needs_attention, pending_actor, version, created_at, updated_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 0, NULL, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?)
+           needs_attention, pending_actor, enrichment_status, version, created_at, updated_at
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 0, NULL, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?)
       `).run(
         id,
         identifier,
@@ -674,6 +696,7 @@ export class Store {
         Number(userAssigned),
         needsAttention,
         pendingActor,
+        enrichmentStatus,
         timestamp,
         timestamp,
       );
@@ -702,6 +725,7 @@ export class Store {
       const issue = this.getIssue(id);
       if (!issue) throw new Error("issue_not_found");
       if (issue.version !== version) throw new Error("version_conflict");
+      if (issue.enrichment_status === "pending" && patch.enrichment_status === undefined) throw new Error("issue_enrichment_pending");
       if (patch.project_id !== undefined && !this.getProject(patch.project_id)) throw new Error("project_not_found");
       if (patch.user_assigned !== undefined) patch.user_assigned = Boolean(patch.user_assigned);
       if (patch.user_assigned === true) {
@@ -749,6 +773,7 @@ export class Store {
         user_assigned: "user_assigned",
         needs_attention: "needs_attention",
         pending_actor: "pending_actor",
+        enrichment_status: "enrichment_status",
       };
       const assignments: string[] = [];
       const values: unknown[] = [];
@@ -758,7 +783,7 @@ export class Store {
         values.push(
           key === "labels" ? JSON.stringify(value)
             : key === "pinned" || key === "agent_enabled" || key === "user_assigned" || key === "needs_attention" ? Number(value)
-              : key === "thread_id" || key === "workspace_path" || key === "agent_id" ? value || null
+              : key === "thread_id" || key === "workspace_path" || key === "agent_id" || key === "enrichment_status" ? value || null
                 : value,
         );
       }
@@ -784,6 +809,7 @@ export class Store {
     const issue = this.getIssue(id);
     if (!issue) throw new Error("issue_not_found");
     if (issue.version !== version) throw new Error("version_conflict");
+    if (issue.enrichment_status === "pending") throw new Error("issue_enrichment_pending");
     const result = this.db.prepare("UPDATE issues SET archived_at = ?, version = version + 1, updated_at = ? WHERE id = ? AND version = ?")
       .run(now(), now(), issue.id, version);
     if (result.changes !== 1) throw new Error("version_conflict");
@@ -877,6 +903,7 @@ export class Store {
           AND pending_actor = 'agent'
           AND agent_enabled = 1
           AND status NOT IN ('backlog', 'done', 'cancelled')
+          AND (enrichment_status IS NULL OR enrichment_status != 'pending')
       `).run(timestamp, issue.id, issue.version);
       if (result.changes !== 1) throw new Error("claim_conflict");
       this.db.exec("COMMIT");

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -517,6 +517,8 @@ export function injectionScript(port: number, accessToken: string, action: "inst
         #\${PANEL_ID} .better-codex-cards { min-height: 0; flex: 1; overflow-y: auto; padding: 0; border-radius: 8px; }
         #\${PANEL_ID} .better-codex-card { box-sizing: border-box; width: 100%; margin-bottom: 8px; border: 1px solid var(--bc-color-hairline, #e5e5e6); border-radius: 8px; background: var(--bc-color-canvas, var(--bc-page, #fff)); padding: 12px 10px; box-shadow: var(--bc-card-shadow, 0 1px 2px rgba(15,23,42,.04),0 2px 6px rgba(15,23,42,.05)); cursor: pointer; transition: border-color .15s, box-shadow .15s, transform .15s; }
         #\${PANEL_ID} .better-codex-card:hover { border-color: color-mix(in srgb, var(--bc-color-text, #1a1c1f) 16%, var(--bc-color-hairline, #e5e5e6)); background: var(--bc-color-canvas, var(--bc-page, #fff)); box-shadow: var(--bc-card-shadow, 0 1px 2px rgba(15,23,42,.04),0 2px 6px rgba(15,23,42,.05)), 0 4px 12px rgba(15,23,42,.06); }
+        #\${PANEL_ID} .better-codex-card.is-enrichment-pending { cursor: wait; opacity: .76; }
+        #\${PANEL_ID} .better-codex-card.is-enrichment-pending:hover { border-color: var(--bc-color-hairline, #e5e5e6); box-shadow: var(--bc-card-shadow, 0 1px 2px rgba(15,23,42,.04),0 2px 6px rgba(15,23,42,.05)); }
         #\${PANEL_ID} .better-codex-card:active { transform: scale(.995); }
         #\${PANEL_ID} .better-codex-card-row, #\${PANEL_ID} .better-codex-card-id, #\${PANEL_ID} .better-codex-card-meta { display: flex; align-items: center; }
         #\${PANEL_ID} .better-codex-card-row { justify-content: space-between; gap: 8px; }
@@ -2006,6 +2008,7 @@ export function injectionScript(port: number, accessToken: string, action: "inst
       panel.querySelector("#better-codex-board").innerHTML = Object.entries(statusLabels).map(([status, statusLabel]) => {
         const issues = visible.filter(issue => issue.status === status);
         const cards = issues.map(issue => {
+          const enrichmentLocked = issue.enrichment_status === "pending";
           const assignedAgent = state.agents.find(agent => agent.id === issue.agent_id);
           const defaultAgent = state.agents.find(agent => agent.is_default);
           const assignee = issue.agent_enabled
@@ -2032,7 +2035,7 @@ export function injectionScript(port: number, accessToken: string, action: "inst
             : issue.user_assigned
               ? '<span class="better-codex-card-assignee"><span class="better-codex-card-avatar is-user is-initials" style="background:' + escapeHtml(state.user.color || "#16a34a") + '">' + escapeHtml(state.user.initials || "你") + '</span><span>' + escapeHtml(state.user.name || "我") + '</span></span>'
               : '<span class="better-codex-card-assignee is-empty">' + icon("user") + '<span>未分配</span></span>';
-          return '<article class="better-codex-card' + (issue.id === draggingIssueId ? " is-dragging" : "") + '" draggable="true" data-issue-id="' + escapeHtml(issue.id) + '"><div class="better-codex-card-row"><div class="better-codex-card-id">' + priorityIcon(issue.priority) + '<span>' + escapeHtml(issue.identifier) + '</span></div>' + activity + '</div><div class="better-codex-card-title">' + escapeHtml(issue.title) + '</div>' + (description ? '<div class="better-codex-card-description">' + escapeHtml(description) + '</div>' : "") + (chips ? '<div class="better-codex-chip-row">' + chips + '</div>' : "") + '<div class="better-codex-card-meta">' + meta + '<span>更新于 ' + timeAgo(issue.updated_at) + '</span></div></article>';
+          return '<article class="better-codex-card' + (issue.id === draggingIssueId ? " is-dragging" : "") + (enrichmentLocked ? " is-enrichment-pending" : "") + '" draggable="' + String(!enrichmentLocked) + '" aria-disabled="' + String(enrichmentLocked) + '" data-issue-id="' + escapeHtml(issue.id) + '"><div class="better-codex-card-row"><div class="better-codex-card-id">' + priorityIcon(issue.priority) + '<span>' + escapeHtml(issue.identifier) + '</span></div>' + activity + '</div><div class="better-codex-card-title">' + escapeHtml(issue.title) + '</div>' + (description ? '<div class="better-codex-card-description">' + escapeHtml(description) + '</div>' : "") + (chips ? '<div class="better-codex-chip-row">' + chips + '</div>' : "") + '<div class="better-codex-card-meta">' + meta + '<span>更新于 ' + timeAgo(issue.updated_at) + '</span></div></article>';
         }).join("");
         return '<section class="better-codex-column" data-status="' + status + '"><div class="better-codex-column-head"><span class="better-codex-column-title">' + statusIcon(status) + '<span>' + statusLabel + '</span><span>' + issues.length + '</span></span><span class="better-codex-column-actions"><button class="better-codex-column-icon" type="button" data-add-status="' + status + '" aria-label="新建任务">' + icon("plus") + '</button></span></div><div class="better-codex-cards">' + (cards || '<div class="better-codex-empty">暂无任务</div>') + '</div></section>';
       }).join("");
@@ -2263,6 +2266,7 @@ export function injectionScript(port: number, accessToken: string, action: "inst
       let selectDismiss = null;
       let conversationTimer = null;
       const sessionId = issueSessionId(issue);
+      const enrichmentLocked = Boolean(issue?.enrichment_status === "pending");
 
       function stopConversationPoll() {
         if (conversationTimer !== null) {
@@ -2290,10 +2294,10 @@ export function injectionScript(port: number, accessToken: string, action: "inst
       }
 
       function header() {
-        const openThreadButton = issue && sessionId
+        const openThreadButton = issue && sessionId && !enrichmentLocked
           ? '<button class="better-codex-dialog-open-thread" type="button" data-dialog-open-thread="' + escapeHtml(sessionId) + '">在会话中打开</button>'
           : "";
-        const startNowButton = issue && !sessionId && !state.autoDispatch && issue.agent_enabled && !issue.active_run_status
+        const startNowButton = issue && !enrichmentLocked && !sessionId && !state.autoDispatch && issue.agent_enabled && !issue.active_run_status
           ? '<button class="better-codex-dialog-start-now" type="button" data-dialog-start-now>立即开始任务</button>'
           : "";
         const title = draft.mode === "agent" ? "通过智能体创建" : issue ? "Issue 详情" : "手动创建";
@@ -2513,6 +2517,7 @@ export function injectionScript(port: number, accessToken: string, action: "inst
         dialog.dataset.mode = draft.mode;
         dialog.dataset.detail = issue ? "true" : "false";
         dialog.dataset.expanded = String(draft.expanded);
+        dialog.dataset.locked = String(enrichmentLocked);
         if (draft.mode === "agent") {
           const selectedAgent = state.agents.find(agent => agent.id === draft.agentId);
           const selectedName = selectedAgent?.name || "Codex";
@@ -2535,6 +2540,12 @@ export function injectionScript(port: number, accessToken: string, action: "inst
           if (startNow) startNow.disabled = disabled;
         };
         updateSubmit();
+        if (enrichmentLocked) {
+          dialog.querySelectorAll("input, textarea, select, button").forEach(control => {
+            if (control.matches("[data-dialog-close], [data-dialog-expand]")) return;
+            control.disabled = true;
+          });
+        }
         content?.addEventListener("input", updateSubmit);
         dialog.querySelector('[name="keep"]')?.addEventListener("change", event => { state.keepCreate = event.currentTarget.checked; });
         const replyInput = dialog.querySelector('[name="reply"]');
@@ -2741,6 +2752,7 @@ export function injectionScript(port: number, accessToken: string, action: "inst
       }
 
       async function submitIssue() {
+        if (enrichmentLocked) return;
         const submit = dialog.querySelector(".better-codex-submit");
         const errorOutput = dialog.querySelector(".better-codex-dialog-error");
         const prompt = draft.prompt.trim();
@@ -2802,7 +2814,7 @@ export function injectionScript(port: number, accessToken: string, action: "inst
       }
 
       async function startIssueNow() {
-        if (!issue) return;
+        if (!issue || enrichmentLocked) return;
         const button = dialog.querySelector("[data-dialog-start-now]");
         const errorOutput = dialog.querySelector(".better-codex-dialog-error");
         const agentId = draft.assignee && !["none", "user", "codex"].includes(draft.assignee) ? draft.assignee : "";
@@ -2862,13 +2874,15 @@ export function injectionScript(port: number, accessToken: string, action: "inst
       }
       const card = event.target.closest("[data-issue-id]");
       const issue = state.issues.find(item => item.id === card?.dataset.issueId);
-      if (issue) return void perform(() => openEditor(issue));
+      if (issue && issue.enrichment_status !== "pending") return void perform(() => openEditor(issue));
     }
 
     function onCardDragStart(event) {
       const card = event.target.closest("[data-issue-id]");
       if (!card || !event.dataTransfer) return;
       const issueId = card.dataset.issueId || "";
+      const issue = state.issues.find(item => item.id === issueId);
+      if (issue?.enrichment_status === "pending") return;
       draggingIssueId = issueId;
       event.dataTransfer.setData("text/plain", issueId);
       event.dataTransfer.effectAllowed = "move";
@@ -2938,7 +2952,7 @@ export function injectionScript(port: number, accessToken: string, action: "inst
       const id = event.dataTransfer?.getData("text/plain");
       const status = event.target.closest("[data-status]")?.dataset.status;
       const issue = state.issues.find(item => item.id === id);
-      if (!issue || !status || issue.status === status) return;
+      if (!issue || issue.enrichment_status === "pending" || !status || issue.status === status) return;
       void perform(async () => {
         await api("/api/issues/" + encodeURIComponent(issue.id), { method: "PATCH", body: JSON.stringify({ version: issue.version, status }) });
         await loadIssues();

--- a/src/server.ts
+++ b/src/server.ts
@@ -392,6 +392,7 @@ export function startServer() {
           agentEnabled,
           agentId,
           userAssigned: body.user_assigned === true,
+          enrichmentStatus: aiEnrich ? "pending" : null,
         });
         if (aiEnrich) worker.enrichIssue(issue, issue.description, agentId);
         else if (issue.agent_enabled && store.isDispatchable(issue)) worker.wake();
@@ -430,6 +431,7 @@ export function startServer() {
           return sendJson(response, 200, updated);
         }
         if (method === "GET" && path[3] === "conversation" && path.length === 4) {
+          if (store.isEnrichmentPending(issue)) throw new Error("issue_enrichment_pending");
           const threadId = issue.run_thread_id || "";
           const conversation = await readConversationResult(threadId);
           return sendJson(response, 200, {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -7,6 +7,7 @@ import { debugLoggingEnabled, runLogPath, workerLogPath } from "./config.js";
 import { Store, type ClaimedIssue, type Issue } from "./db.js";
 
 const interval = 60000;
+const enrichmentTimeout = 30000;
 
 function workerDebug(event: string, fields: Record<string, unknown> = {}) {
   if (!debugLoggingEnabled) return;
@@ -54,6 +55,7 @@ export class IssueWorker {
   start() {
     this.stopped = false;
     this.store.recoverInterruptedRuns();
+    for (const issue of this.store.listPendingEnrichmentIssues()) this.enrichIssue(issue, issue.description, issue.agent_id || "");
     this.schedule(0);
   }
 
@@ -85,12 +87,16 @@ export class IssueWorker {
 
   enrichIssue(issue: Issue, prompt: string, agentId: string) {
     const workspacePath = issue.workspace_path || "";
-    if (!workspacePath || this.stopped) {
+    if (this.enrichments.has(issue.id) || this.stopped) {
       workerDebug("enrichment_skipped", {
         issue_id: issue.id,
         identifier: issue.identifier,
-        reason: !workspacePath ? "workspace_missing" : "worker_stopped",
+        reason: this.stopped ? "worker_stopped" : "already_running",
       });
+      return;
+    }
+    if (!workspacePath) {
+      this.failEnrichment(issue, "workspace_missing");
       return;
     }
     workerDebug("enrichment_started", {
@@ -124,16 +130,26 @@ export class IssueWorker {
     });
     this.enrichments.set(issue.id, child);
     const messages: string[] = [];
+    let finished = false;
+    let timeout: NodeJS.Timeout | null = setTimeout(() => {
+      workerDebug("enrichment_timeout", { issue_id: issue.id, identifier: issue.identifier, timeout_ms: enrichmentTimeout });
+      finish("timeout");
+      child.kill("SIGTERM");
+    }, enrichmentTimeout);
     const lines = createInterface({ input: child.stdout! });
     lines.on("line", line => {
       const message = enrichmentMessage(line);
       if (message) messages.push(message);
     });
-    const finish = (event: "error" | "close", code?: number | null, signal?: NodeJS.Signals | null) => {
+    const finish = (event: "error" | "close" | "timeout", code?: number | null, signal?: NodeJS.Signals | null) => {
+      if (finished) return;
+      finished = true;
+      if (timeout) clearTimeout(timeout);
+      timeout = null;
       lines.close();
       this.enrichments.delete(issue.id);
       const raw = messages.at(-1) || "";
-      const result = parseEnrichment(raw);
+      const result = event === "close" && code === 0 ? parseEnrichment(raw) : null;
       workerDebug("enrichment_finished", {
         issue_id: issue.id,
         identifier: issue.identifier,
@@ -165,17 +181,30 @@ export class IssueWorker {
         });
         return;
       }
-      const fallback = fallbackEnrichment(issue.identifier, issue.description);
       try {
         const updated = this.store.updateIssue(issue.id, current.version, {
-          title: result?.title || fallback.title,
-          description: result?.description || fallback.description,
-          status: "todo",
-          agent_enabled: true,
-          agent_id: agentId,
-          user_assigned: false,
-          pending_actor: "agent",
-          needs_attention: true,
+          ...(result
+            ? {
+                title: result.title,
+                description: result.description,
+                status: "todo",
+                agent_enabled: true,
+                agent_id: agentId,
+                user_assigned: false,
+                pending_actor: "agent",
+                needs_attention: true,
+                enrichment_status: null,
+              }
+            : {
+                title: "任务理解失败",
+                status: "blocked",
+                agent_enabled: true,
+                agent_id: agentId,
+                user_assigned: false,
+                pending_actor: "user",
+                needs_attention: true,
+                enrichment_status: "failed",
+              }),
         });
         workerDebug("enrichment_applied", {
           issue_id: issue.id,
@@ -203,6 +232,28 @@ export class IssueWorker {
       finish("error");
     });
     child.once("close", (code, signal) => finish("close", code, signal));
+  }
+
+  private failEnrichment(issue: Issue, reason: string) {
+    workerDebug("enrichment_failed", { issue_id: issue.id, identifier: issue.identifier, reason });
+    try {
+      this.store.updateIssue(issue.id, issue.version, {
+        title: "任务理解失败",
+        status: "blocked",
+        agent_enabled: true,
+        agent_id: issue.agent_id,
+        user_assigned: false,
+        pending_actor: "user",
+        needs_attention: true,
+        enrichment_status: "failed",
+      });
+    } catch (error) {
+      workerDebug("enrichment_apply_failed", {
+        issue_id: issue.id,
+        identifier: issue.identifier,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
   }
 
   private schedule(delay = interval) {

--- a/test/core.test.ts
+++ b/test/core.test.ts
@@ -101,6 +101,30 @@ test("core workflow persists, orders status moves, and rejects stale writes", ()
     assert.notEqual(globallyUnique.identifier, active.identifier);
     assert.ok(second.sort_order > first.sort_order);
 
+    const enriching = store.createIssue({
+      projectId: project.id,
+      title: "原始需求",
+      description: "原始需求",
+      agentEnabled: true,
+      workspacePath: target.directory,
+      enrichmentStatus: "pending",
+    });
+    assert.equal(enriching.title, "正在理解任务");
+    assert.equal(enriching.status, "backlog");
+    assert.equal(enriching.enrichment_status, "pending");
+    assert.equal(store.isDispatchable(enriching), false);
+    assert.throws(() => store.updateIssue(enriching.id, enriching.version, { title: "不能编辑" }), /issue_enrichment_pending/);
+    const enriched = store.updateIssue(enriching.id, enriching.version, {
+      title: "整理后的标题",
+      description: "整理后的详情",
+      status: "todo",
+      pending_actor: "agent",
+      needs_attention: true,
+      enrichment_status: null,
+    });
+    assert.equal(enriched.enrichment_status, null);
+    assert.equal(store.isDispatchable(enriched), true);
+
     const reassigned = store.updateIssue(second.id, second.version, { project_id: samePrefixProject.id });
     assert.equal(reassigned.project_id, samePrefixProject.id);
     assert.ok(reassigned.sort_order > globallyUnique.sort_order);

--- a/test/dom.test.ts
+++ b/test/dom.test.ts
@@ -507,7 +507,10 @@ test("issue cards show project icon and assignee instead of session entry", () =
   const startNowMarkup = source.indexOf("data-dialog-start-now");
   assert.ok(startNowMarkup > headerStart && startNowMarkup < footerStart);
   assert.equal(source.slice(footerStart, source.indexOf("function renderDialog()", footerStart)).includes("data-dialog-start-now"), false);
-  assert.ok(source.includes("if (issue) return void perform(() => openEditor(issue))"));
+  assert.ok(source.includes('if (issue && issue.enrichment_status !== "pending") return void perform(() => openEditor(issue))'));
+  assert.ok(source.includes('draggable="\' + String(!enrichmentLocked) + \'"'));
+  assert.ok(source.includes('if (!issue || enrichmentLocked) return;'));
+  assert.ok(source.includes('if (enrichmentLocked) return;'));
   assert.ok(!source.includes("issue?.run_thread_id || issue?.thread_id || \"\""));
   assert.ok(!source.includes("(sessionId ? ' data-thread=\""));
   assert.doesNotMatch(source, /任务尚未关联 Session/);


### PR DESCRIPTION
## What changed

- Persist `enrichment_status` so newly created agent Issues remain locked while being understood.
- Prevent dispatch, editing, starting, archiving, dragging, and conversation access while enrichment is pending.
- Add a 30-second enrichment timeout and move failed or invalid results to `blocked` with the title `任务理解失败`.
- Resume pending enrichment jobs after runtime restart.
- Add database and UI regression coverage.

## Root cause

The enrichment child process could finish successfully after the Issue had already been claimed. The worker then discarded the valid result because the Issue version had changed, while the main session continued with the original title and description.

## Validation

- `npm test` — 94 passed
- `npm run build` — passed
- `git diff --check` — passed