### PR TITLE
feat: add dual-profile installs and compatibility gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,8 @@ jobs:
     strategy:
       matrix:
         runner:
-          - macos-15
+          - macos-26
+          - macos-15-intel
           - windows-2025
     runs-on: ${{ matrix.runner }}
     steps:
@@ -27,3 +28,17 @@ jobs:
       - run: npm run build
       - run: npm test
       - run: npm run package:binary
+      - name: Install current local package twice
+        run: node scripts/test-local-install.mjs
+
+  node-24-lifecycle:
+    runs-on: windows-2025
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - run: npx tsx --test test/cdp-lifecycle.test.ts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,11 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: better-codex-release
+  queue: max
+  cancel-in-progress: false
+
 jobs:
   validate-release:
     runs-on: ubuntu-latest
@@ -21,6 +26,8 @@ jobs:
         run: |
           set -euo pipefail
           version="$(node -p "require('./package.json').version")"
+          lock_version="$(node -p "require('./package-lock.json').packages[''].version")"
+          core_version="$(node -e "const source=require('fs').readFileSync('src/compatibility.ts','utf8'); const match=source.match(/export const coreVersion = \"([^\"]+)\"/); process.stdout.write(match?.[1] || '')")"
           expected_tag="v$version"
           if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             printf 'Package version %s is not a release version.\n' "$version" >&2
@@ -28,6 +35,10 @@ jobs:
           fi
           if [ "$GITHUB_REF_NAME" != "$expected_tag" ]; then
             printf 'Release tag %s does not match package version %s.\n' "$GITHUB_REF_NAME" "$version" >&2
+            exit 1
+          fi
+          if [ "$lock_version" != "$version" ] || [ "$core_version" != "$version" ]; then
+            printf 'Version mismatch: package=%s lock=%s core=%s.\n' "$version" "$lock_version" "$core_version" >&2
             exit 1
           fi
           escaped_version="${version//./\\.}"
@@ -77,6 +88,8 @@ jobs:
       - run: npm run package:binary
         env:
           BETTER_CODEX_REQUIRE_SIGNING: "0"
+      - name: Install current local package twice
+        run: node scripts/test-local-install.mjs
       - uses: actions/upload-artifact@v4
         with:
           name: better-codex-${{ matrix.runner }}
@@ -118,6 +131,23 @@ jobs:
           path: release
           merge-multiple: true
       - run: git fetch origin main && git checkout -B main origin/main
+      - name: Refuse to downgrade the Homebrew formula
+        shell: bash
+        run: |
+          set -euo pipefail
+          current="$(sed -n 's/^  version "\([0-9][0-9.]*\)"$/\1/p' Formula/better-codex.rb)"
+          next="${GITHUB_REF_NAME#v}"
+          node -e '
+            const [current, next] = process.argv.slice(1);
+            const parts = value => value.split(".").map(Number);
+            const left = parts(current);
+            const right = parts(next);
+            const comparison = left.findIndex((value, index) => value !== right[index]);
+            if (comparison >= 0 && left[comparison] > right[comparison]) {
+              console.error(`Refusing to downgrade Homebrew formula from ${current} to ${next}.`);
+              process.exit(1);
+            }
+          ' "$current" "$next"
       - run: sha256sum release/*.tar.gz | sed 's#release/##' > release/checksums.txt
       - run: node scripts/render-homebrew-formula.mjs --version "${GITHUB_REF_NAME#v}" --checksums release/checksums.txt --output Formula/better-codex.rb
       - run: |
@@ -125,4 +155,6 @@ jobs:
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
           git add Formula/better-codex.rb
           git commit -m "chore(release): better-codex ${GITHUB_REF_NAME#v}"
+          git fetch origin main
+          git rebase origin/main
           git push origin HEAD:main

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ run
 better-codex.db*
 plan/
 homepage/bettercodex-site/
+.vs/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to Better Codex are recorded here.
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-08-10
+
+### Added
+
+- Run stable binaries and source checkouts side by side with isolated data directories and launchers, handing off the active Codex page injection when switching profiles.
+- Verify that packaged installers can install and reinstall the current archive on Apple silicon, Intel macOS, and Windows during CI and release builds.
+
+### Changed
+
+- Label source checkouts as development builds in the update screen and limit them to compatibility-layer updates.
+
+### Fixed
+
+- Keep native progress written to stderr from becoming a Windows PowerShell 5.1 installation failure.
+- Validate local package inputs and normalize update-key line endings during installer compatibility tests.
+- Preserve legacy injection ownership during profile handoff and coalesce repeated launcher clicks so the latest profile request wins.
+
 ## [0.3.17] - 2026-08-10
 
 ### Changed
@@ -196,7 +213,8 @@ All notable changes to Better Codex are recorded here.
 - Run Agent-owned Issues through an automated local workflow with visible review states.
 - Support macOS and Windows with a managed runtime, compatibility layer, signed updates, and release installers.
 
-[Unreleased]: https://github.com/Ericwong5021/better-codex/compare/v0.3.17...HEAD
+[Unreleased]: https://github.com/Ericwong5021/better-codex/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/Ericwong5021/better-codex/compare/v0.3.17...v0.4.0
 [0.3.17]: https://github.com/Ericwong5021/better-codex/compare/v0.3.16...v0.3.17
 [0.3.16]: https://github.com/Ericwong5021/better-codex/compare/v0.3.15...v0.3.16
 [0.3.15]: https://github.com/Ericwong5021/better-codex/compare/v0.3.14...v0.3.15

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,17 @@ npm run better-codex -- version
 npm run better-codex -- doctor
 ```
 
+To keep the released binary and source checkout installed side by side, create the isolated development launcher:
+
+```bash
+npm run dev:install
+npm run dev:status
+```
+
+This uses `~/.better-codex-dev` and creates `Better Codex Dev` separately from the stable `Better Codex` launcher. Only one profile owns the Codex page injection at a time. Run `npm run dev:uninstall` to remove the development launcher without deleting its data.
+
+On Windows, set `BETTER_CODEX_STABLE_EXECUTABLE` before `npm run dev:install` when the stable binary was installed outside its default location.
+
 To build a platform package, run this on the target platform:
 
 ```bash

--- a/README.en.md
+++ b/README.en.md
@@ -143,16 +143,16 @@ better-codex uninstall         # uninstall completely and delete local data
 
 Requires Node.js 22.5 or later.
 
+If the stable build is already installed, install the source checkout as a separate development instance. Stable keeps `~/.better-codex` and the `Better Codex` launcher; development uses `~/.better-codex-dev` and `Better Codex Dev`. Their data, logs, and update state stay isolated, and opening either launcher deactivates the other instance's page injection first.
+
 ```bash
 git clone https://github.com/Ericwong5021/better-codex.git
 cd better-codex
 npm ci
-npm run build
-npm link
-better-codex mcp install
-better-codex inject --launch
-better-codex launcher install
+npm run dev:install
 ```
+
+The development instance does not auto-update its core. Pull source changes and run `npm run build` to refresh it. Use `npm run dev:status` to inspect the development instance and `npm run dev:uninstall` to remove its launcher and stop it while preserving development data.
 
 ## Community
 

--- a/README.md
+++ b/README.md
@@ -143,16 +143,16 @@ better-codex uninstall         # uninstall completely and delete local data
 
 Requires Node.js 22.5 or later.
 
+If the stable build is already installed, install the source checkout as a separate development instance. Stable keeps `~/.better-codex` and the `Better Codex` launcher; development uses `~/.better-codex-dev` and `Better Codex Dev`. Their data, logs, and update state stay isolated, and opening either launcher deactivates the other instance's page injection first.
+
 ```bash
 git clone https://github.com/Ericwong5021/better-codex.git
 cd better-codex
 npm ci
-npm run build
-npm link
-better-codex mcp install
-better-codex inject --launch
-better-codex launcher install
+npm run dev:install
 ```
+
+The development instance does not auto-update its core. Pull source changes and run `npm run build` to refresh it. Use `npm run dev:status` to inspect the development instance and `npm run dev:uninstall` to remove its launcher and stop it while preserving development data.
 
 ## Community
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -143,16 +143,16 @@ better-codex uninstall         # 完全卸载并删除本地数据
 
 需要 Node.js 22.5 或更新版本。
 
+如果电脑上已经安装正式版，推荐把源码作为独立开发实例安装。正式版继续使用 `~/.better-codex` 和启动器 `Better Codex`；开发版使用 `~/.better-codex-dev` 和启动器 `Better Codex Dev`。两个实例的数据、日志和更新状态彼此隔离，点击任一启动器时会先停用另一个实例的页面注入。
+
 ```bash
 git clone https://github.com/Ericwong5021/better-codex.git
 cd better-codex
 npm ci
-npm run build
-npm link
-better-codex mcp install
-better-codex inject --launch
-better-codex launcher install
+npm run dev:install
 ```
+
+开发实例不会自动升级核心版本；拉取源码并执行 `npm run build` 即可刷新。使用 `npm run dev:status` 检查开发实例，使用 `npm run dev:uninstall` 移除开发版快捷方式并停止开发实例，开发数据会保留。
 
 ## 社区
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "better-codex",
-  "version": "0.3.17",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "better-codex",
-      "version": "0.3.17",
+      "version": "0.4.0",
       "os": [
         "darwin",
         "win32"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "better-codex",
-  "version": "0.3.17",
+  "version": "0.4.0",
   "private": true,
   "license": "Apache-2.0",
   "type": "module",
@@ -43,7 +43,10 @@
   "scripts": {
     "build": "tsc && node scripts/refresh-local-install.mjs && node scripts/refresh-injector.mjs",
     "dev": "tsx src/cli.ts serve",
+    "dev:install": "npm run build && node scripts/development-instance.mjs install",
     "dev:mockup": "node scripts/dev-mockup.mjs",
+    "dev:status": "node scripts/development-instance.mjs status",
+    "dev:uninstall": "node scripts/development-instance.mjs uninstall",
     "package:binary": "node scripts/package.mjs",
     "package:update-manifest": "node scripts/create-update-manifest.mjs release",
     "start": "node dist/cli.js serve",

--- a/scripts/development-instance.mjs
+++ b/scripts/development-instance.mjs
@@ -1,0 +1,89 @@
+import { spawnSync } from "node:child_process";
+import { copyFileSync, existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const executable = join(root, "dist", "cli.js");
+const home = resolve(process.env.BETTER_CODEX_DEV_HOME || join(homedir(), ".better-codex-dev"));
+const stableHome = resolve(process.env.BETTER_CODEX_STABLE_HOME || join(homedir(), ".better-codex"));
+const environment = {
+  ...process.env,
+  BETTER_CODEX_PROFILE: "development",
+  BETTER_CODEX_HOME: home,
+  BETTER_CODEX_PEER_HOME: stableHome,
+  BETTER_CODEX_DISABLE_DELEGATION: "1",
+};
+
+function run(args, capture = false) {
+  const result = spawnSync(process.execPath, [executable, ...args], {
+    cwd: root,
+    encoding: "utf8",
+    env: environment,
+    stdio: capture ? "pipe" : "inherit",
+  });
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    if (capture && result.stderr) process.stderr.write(result.stderr);
+    process.exit(result.status ?? 1);
+  }
+  return capture ? result.stdout.trim() : "";
+}
+
+function ensureStableWindowsLauncher() {
+  if (process.platform !== "win32") return { checked: false, reason: "windows_only" };
+  const defaultExecutable = process.env.LOCALAPPDATA ? join(process.env.LOCALAPPDATA, "BetterCodex", "bin", "better-codex.exe") : "";
+  const configuredExecutable = process.env.BETTER_CODEX_STABLE_EXECUTABLE || defaultExecutable;
+  if (!configuredExecutable) throw new Error("stable_binary_required");
+  const officialExecutable = resolve(configuredExecutable);
+  if (!existsSync(officialExecutable)) throw new Error("stable_binary_required");
+  const stableEnvironment = {
+    ...process.env,
+    BETTER_CODEX_PROFILE: "stable",
+    BETTER_CODEX_HOME: stableHome,
+    BETTER_CODEX_PEER_HOME: home,
+    BETTER_CODEX_DISABLE_DELEGATION: "1",
+  };
+  delete stableEnvironment.BETTER_CODEX_LAUNCHER_PATH;
+  const result = spawnSync(officialExecutable, ["launcher", "install"], { encoding: "utf8", env: stableEnvironment, stdio: "inherit" });
+  if (result.error) throw result.error;
+  if (result.status !== 0) process.exit(result.status ?? 1);
+  const versionResult = spawnSync(officialExecutable, ["version", "--json"], { encoding: "utf8", env: stableEnvironment });
+  let supportsProfiles = false;
+  try { supportsProfiles = JSON.parse(versionResult.stdout).profile === "stable"; } catch {}
+  const launchArguments = supportsProfiles ? "launch" : "start --launch";
+  mkdirSync(stableHome, { recursive: true });
+  const commandLine = `"${officialExecutable.replace(/"/g, "\"\"")}"`;
+  writeFileSync(join(stableHome, "Better Codex Launcher.vbs"), `Option Explicit
+Dim shell
+Set shell = CreateObject("WScript.Shell")
+shell.Environment("Process")("BETTER_CODEX_PROFILE") = "stable"
+shell.Environment("Process")("BETTER_CODEX_HOME") = "${stableHome.replace(/"/g, "\"\"")}"
+shell.Environment("Process")("BETTER_CODEX_PEER_HOME") = "${home.replace(/"/g, "\"\"")}"
+shell.Run "${commandLine.replace(/"/g, '""')}" & " ${launchArguments}", 0, False
+`, { mode: 0o600 });
+  return { checked: true, executable: officialExecutable, home: stableHome, supportsProfiles, launchArguments };
+}
+
+if (!existsSync(executable)) throw new Error("development_build_required");
+const action = process.argv[2];
+
+if (action === "install") {
+  const stable = ensureStableWindowsLauncher();
+  mkdirSync(home, { recursive: true });
+  copyFileSync(join(root, "assets", "update-public-key.pem"), join(home, "update-public-key.pem"));
+  run(["launcher", "install"]);
+  console.log(JSON.stringify({ installed: true, profile: "development", home, stable }, null, 2));
+} else if (action === "uninstall") {
+  run(["stop"]);
+  run(["launcher", "uninstall"]);
+  console.log(JSON.stringify({ uninstalled: true, profile: "development", home, dataPreserved: true }, null, 2));
+} else if (action === "status") {
+  const launcher = JSON.parse(run(["launcher", "status"], true) || "{}");
+  const status = JSON.parse(run(["status"], true) || "{}");
+  console.log(JSON.stringify({ profile: "development", home, launcher, ...status }, null, 2));
+} else {
+  console.error("Usage: node scripts/development-instance.mjs install|uninstall|status");
+  process.exit(1);
+}

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -18,6 +18,20 @@ function Write-Ok([string]$Message) {
   Write-Host "[OK] $Message" -ForegroundColor Green
 }
 
+function Invoke-NativeCapture([string]$Executable, [string[]]$Arguments) {
+  $previousErrorActionPreference = $ErrorActionPreference
+  try {
+    # Windows PowerShell 5.1 promotes redirected native stderr to error records.
+    # Keep progress output capturable and use the process exit code as the authority.
+    $ErrorActionPreference = "Continue"
+    $output = (& $Executable @Arguments 2>&1 | Out-String)
+    $exitCode = $LASTEXITCODE
+    return [PSCustomObject]@{ Output = $output; ExitCode = $exitCode }
+  } finally {
+    $ErrorActionPreference = $previousErrorActionPreference
+  }
+}
+
 function Resolve-ReleaseTag([string]$RepositoryName, [string]$RequestedVersion) {
   $candidate = if ($RequestedVersion) { $RequestedVersion } elseif ($env:BETTER_CODEX_VERSION) { $env:BETTER_CODEX_VERSION } else { "" }
   if ($candidate -and $candidate -ne "latest") {
@@ -97,18 +111,18 @@ function Test-VersionAtLeast([string]$Current, [string]$Target) {
 
 function Invoke-ExistingUpgrade([string]$Executable, [string]$TargetVersion) {
   try {
-    & $Executable update 2>&1 | Out-Null
-    if ($LASTEXITCODE -ne 0) { return $false }
+    $updateResult = Invoke-NativeCapture $Executable @("update")
+    if ($updateResult.ExitCode -ne 0) { return $false }
     $updatedVersion = Get-InstalledVersion $Executable
     if (-not (Test-VersionAtLeast $updatedVersion $TargetVersion)) { return $false }
     if (-not $NoService) {
-      & $Executable service restart 2>&1 | Out-Null
-      if ($LASTEXITCODE -ne 0) { return $false }
+      $restartResult = Invoke-NativeCapture $Executable @("service", "restart")
+      if ($restartResult.ExitCode -ne 0) { return $false }
       Start-Sleep -Milliseconds 800
-      & $Executable inject --launch 2>&1 | Out-Null
-      if ($LASTEXITCODE -ne 0) { return $false }
-      & $Executable launcher install 2>&1 | Out-Null
-      if ($LASTEXITCODE -ne 0) { return $false }
+      $injectResult = Invoke-NativeCapture $Executable @("inject", "--launch")
+      if ($injectResult.ExitCode -ne 0) { return $false }
+      $launcherResult = Invoke-NativeCapture $Executable @("launcher", "install")
+      if ($launcherResult.ExitCode -ne 0) { return $false }
       $doctor = (& $Executable doctor | Out-String | ConvertFrom-Json)
       if (-not $doctor.ok) { return $false }
     }
@@ -122,8 +136,8 @@ function Invoke-ExistingUpgrade([string]$Executable, [string]$TargetVersion) {
 function Test-InstallationReady([string]$Executable) {
   if ($NoService) { return $true }
   try {
-    & $Executable launcher install 2>&1 | Out-Null
-    if ($LASTEXITCODE -ne 0) { return $false }
+    $launcherResult = Invoke-NativeCapture $Executable @("launcher", "install")
+    if ($launcherResult.ExitCode -ne 0) { return $false }
     $doctor = (& $Executable doctor 2>$null | Out-String | ConvertFrom-Json)
     return [bool]$doctor.ok
   } catch {
@@ -149,11 +163,12 @@ $installLockAcquired = $false
 try {
   try { $installLockAcquired = $installMutex.WaitOne(0) } catch [Threading.AbandonedMutexException] { $installLockAcquired = $true }
   if (-not $installLockAcquired) { throw "Another Better Codex installation is already running." }
-$Version = Resolve-ReleaseTag $Repository $Version
-$targetVersion = $Version.TrimStart("v")
+$localArchive = if ($env:BETTER_CODEX_ARCHIVE) { [IO.Path]::GetFullPath($env:BETTER_CODEX_ARCHIVE) } else { $null }
+if (-not $localArchive) { $Version = Resolve-ReleaseTag $Repository $Version }
+$targetVersion = if ($Version) { $Version.TrimStart("v") } else { "" }
 $installedVersion = Get-InstalledVersion $executable
 
-if ($installedVersion -and (Test-VersionAtLeast $installedVersion $targetVersion) -and (Test-Path (Join-Path $skillDirectory "SKILL.md")) -and (Test-Path $updatePublicKeyPath)) {
+if (-not $localArchive -and $installedVersion -and (Test-VersionAtLeast $installedVersion $targetVersion) -and (Test-Path (Join-Path $skillDirectory "SKILL.md")) -and (Test-Path $updatePublicKeyPath)) {
   try {
     $updateCheck = (& $executable update check 2>$null | Out-String | ConvertFrom-Json)
     if ($updateCheck.checked -and -not (($updateCheck.core.available) -or ($updateCheck.compatibility.available))) {
@@ -168,7 +183,7 @@ if ($installedVersion -and (Test-VersionAtLeast $installedVersion $targetVersion
   }
 }
 
-if ($installedVersion) {
+if (-not $localArchive -and $installedVersion) {
   Write-Step "Better Codex v$installedVersion is installed; upgrading to v$targetVersion..."
   $updateCheck = $null
   try {
@@ -191,34 +206,55 @@ if ($installedVersion) {
 $workDirectory = Join-Path ([IO.Path]::GetTempPath()) ("better-codex-" + [guid]::NewGuid())
 New-Item -ItemType Directory -Path $workDirectory | Out-Null
 try {
-  $tag = $Version
-  $number = $tag.TrimStart("v")
-  $name = "better-codex-cli-$number-win32-amd64.zip"
-  $base = "https://github.com/$Repository/releases/download/$tag"
-  $archive = Join-Path $workDirectory $name
-  $checksums = Join-Path $workDirectory "checksums.txt"
-  $publicKey = Join-Path $workDirectory "update-public-key.pem"
-  Write-Step "Downloading $name..."
-  Invoke-WebRequest -UseBasicParsing -Uri "$base/$name" -OutFile $archive
-  Write-Step "Downloading checksums and update key..."
-  Invoke-WebRequest -UseBasicParsing -Uri "$base/checksums.txt" -OutFile $checksums
-  Invoke-WebRequest -UseBasicParsing -Uri "$base/update-public-key.pem" -OutFile $publicKey
+  if ($localArchive) {
+    $archive = $localArchive
+    $name = [IO.Path]::GetFileName($archive)
+    $checksums = if ($env:BETTER_CODEX_CHECKSUMS) { [IO.Path]::GetFullPath($env:BETTER_CODEX_CHECKSUMS) } else { Join-Path ([IO.Path]::GetDirectoryName($archive)) "checksums.txt" }
+    $publicKey = if ($env:BETTER_CODEX_UPDATE_PUBLIC_KEY_FILE) { [IO.Path]::GetFullPath($env:BETTER_CODEX_UPDATE_PUBLIC_KEY_FILE) } else { "" }
+    if (-not (Test-Path -LiteralPath $archive -PathType Leaf)) { throw "Local Better Codex archive not found: $archive" }
+    if (-not (Test-Path -LiteralPath $checksums -PathType Leaf)) { throw "Local Better Codex checksums not found: $checksums" }
+    Write-Step "Installing from local package $name..."
+  } else {
+    $tag = $Version
+    $number = $tag.TrimStart("v")
+    $name = "better-codex-cli-$number-win32-amd64.zip"
+    $base = "https://github.com/$Repository/releases/download/$tag"
+    $archive = Join-Path $workDirectory $name
+    $checksums = Join-Path $workDirectory "checksums.txt"
+    $publicKey = Join-Path $workDirectory "update-public-key.pem"
+    Write-Step "Downloading $name..."
+    Invoke-WebRequest -UseBasicParsing -Uri "$base/$name" -OutFile $archive
+    Write-Step "Downloading checksums and update key..."
+    Invoke-WebRequest -UseBasicParsing -Uri "$base/checksums.txt" -OutFile $checksums
+    Invoke-WebRequest -UseBasicParsing -Uri "$base/update-public-key.pem" -OutFile $publicKey
+  }
   Write-Step "Verifying SHA-256 checksum..."
   $expected = ((Get-Content $checksums | Where-Object { $_ -match [regex]::Escape($name) }) -split "\s+")[0]
   if (-not $expected) { throw "No checksum found for $name." }
   $actual = (Get-FileHash -Algorithm SHA256 $archive).Hash.ToLowerInvariant()
   if ($actual -ne $expected.ToLowerInvariant()) { throw "Checksum mismatch for $name." }
-  $actualPublicKey = (Get-FileHash -Algorithm SHA256 $publicKey).Hash.ToLowerInvariant()
-  if ($actualPublicKey -ne $UpdateKeySha256) { throw "Update public key mismatch." }
   Write-Step "Extracting package..."
   Expand-Archive -LiteralPath $archive -DestinationPath $workDirectory -Force
+  if (-not $publicKey -and (Test-Path -LiteralPath (Join-Path $workDirectory "update-public-key.pem") -PathType Leaf)) {
+    $publicKey = Join-Path $workDirectory "update-public-key.pem"
+  }
+  if (-not $publicKey -or -not (Test-Path -LiteralPath $publicKey -PathType Leaf)) { throw "Update public key is missing." }
+  $normalizedPublicKey = [IO.File]::ReadAllText($publicKey).Replace("`r`n", "`n")
+  $publicKeyHasher = [Security.Cryptography.SHA256]::Create()
+  try {
+    $actualPublicKey = -join ($publicKeyHasher.ComputeHash([Text.UTF8Encoding]::new($false).GetBytes($normalizedPublicKey)) | ForEach-Object { $_.ToString("x2") })
+  } finally {
+    $publicKeyHasher.Dispose()
+  }
+  if ($actualPublicKey -ne $UpdateKeySha256) { throw "Update public key mismatch." }
   $packagedExecutable = Join-Path $workDirectory "better-codex.exe"
   $packagedSkill = Join-Path $workDirectory "skills\better-codex"
   if (-not (Test-Path $packagedExecutable)) { throw "Better Codex executable is missing from the package." }
   if (-not (Test-Path (Join-Path $packagedSkill "SKILL.md"))) { throw "Better Codex skill is missing from the package." }
   $packagedVersion = Get-PackagedCoreVersion $packagedExecutable (Join-Path $workDirectory "validation-home")
   if (-not $packagedVersion) { throw "Unable to read the packaged Better Codex version." }
-  if ($packagedVersion -ne $targetVersion) { throw "Package version $packagedVersion does not match target v$targetVersion. Installation cancelled." }
+  if ($targetVersion -and $packagedVersion -ne $targetVersion) { throw "Package version $packagedVersion does not match target v$targetVersion. Installation cancelled." }
+  if (-not $targetVersion) { $targetVersion = $packagedVersion }
   $backupDirectory = Join-Path $workDirectory "previous"
   New-Item -ItemType Directory -Force -Path $backupDirectory | Out-Null
   $backupExecutable = Join-Path $backupDirectory "better-codex.exe"
@@ -271,18 +307,18 @@ try {
   if ($LASTEXITCODE -ne 0) { throw "Better Codex executable verification failed." }
   if (-not $NoService) {
     Write-Step "Registering runtime and injecting Better Codex..."
-    $setupOutput = (& $executable setup --yes 2>&1 | Out-String)
-    $setupExitCode = $LASTEXITCODE
-    if ($setupExitCode -ne 0) {
-      Write-Host ($setupOutput.TrimEnd())
-      throw "Better Codex setup failed with exit code $setupExitCode."
+    $setupResult = Invoke-NativeCapture $executable @("setup", "--yes")
+    if ($setupResult.ExitCode -ne 0) {
+      Write-Host ($setupResult.Output.TrimEnd())
+      throw "Better Codex setup failed with exit code $($setupResult.ExitCode)."
     }
     Write-Step "Running installation diagnostics..."
     $doctor = $null
     $doctorOutput = $null
     for ($attempt = 1; $attempt -le 8; $attempt++) {
-      $doctorOutput = (& $executable doctor 2>&1 | Out-String)
-      $doctorExitCode = $LASTEXITCODE
+      $doctorResult = Invoke-NativeCapture $executable @("doctor")
+      $doctorOutput = $doctorResult.Output
+      $doctorExitCode = $doctorResult.ExitCode
       try {
         $doctor = $doctorOutput | ConvertFrom-Json
       } catch {
@@ -306,10 +342,12 @@ try {
     $displayVersion = if ($readyVersion) { $readyVersion } else { "unknown" }
     throw "Installed Better Codex version $displayVersion does not match target v$targetVersion."
   }
-  $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
-  if ($null -eq $userPath) { $userPath = "" }
-  if (-not (($userPath -split ";") -contains $BinDirectory)) {
-    [Environment]::SetEnvironmentVariable("Path", (($userPath.TrimEnd(";") + ";" + $BinDirectory).TrimStart(";")), "User")
+  if ($env:BETTER_CODEX_SKIP_PATH_UPDATE -ne "1") {
+    $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+    if ($null -eq $userPath) { $userPath = "" }
+    if (-not (($userPath -split ";") -contains $BinDirectory)) {
+      [Environment]::SetEnvironmentVariable("Path", (($userPath.TrimEnd(";") + ";" + $BinDirectory).TrimStart(";")), "User")
+    }
   }
   Write-Ok "Better Codex v$targetVersion is ready"
   } catch {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -264,6 +264,9 @@ if [ -n "${BETTER_CODEX_ARCHIVE:-}" ]; then
   ARCHIVE="$BETTER_CODEX_ARCHIVE"
   CHECKSUMS="${BETTER_CODEX_CHECKSUMS:-$(dirname "$ARCHIVE")/checksums.txt}"
   UPDATE_PUBLIC_KEY="${BETTER_CODEX_UPDATE_PUBLIC_KEY_FILE:-}"
+  [ -f "$ARCHIVE" ] || { echo "Local Better Codex archive not found: $ARCHIVE" >&2; exit 1; }
+  [ -f "$CHECKSUMS" ] || { echo "Local Better Codex checksums not found: $CHECKSUMS" >&2; exit 1; }
+  printf '[Better Codex] Installing from local package %s...\n' "$(basename "$ARCHIVE")"
 else
   VERSION="$TARGET_VERSION"
   NAME="better-codex-cli-$VERSION-darwin-$ARCH.tar.gz"
@@ -291,7 +294,7 @@ tar -xzf "$ARCHIVE" -C "$WORK_DIR"
 if [ -z "$UPDATE_PUBLIC_KEY" ] && [ -f "$WORK_DIR/update-public-key.pem" ]; then
   UPDATE_PUBLIC_KEY="$WORK_DIR/update-public-key.pem"
 fi
-if [ -z "$UPDATE_PUBLIC_KEY" ] || [ "$(shasum -a 256 "$UPDATE_PUBLIC_KEY" | awk '{print $1}')" != "$UPDATE_KEY_SHA256" ]; then
+if [ -z "$UPDATE_PUBLIC_KEY" ] || [ "$(tr -d '\r' < "$UPDATE_PUBLIC_KEY" | shasum -a 256 | awk '{print $1}')" != "$UPDATE_KEY_SHA256" ]; then
   echo "Update public key mismatch." >&2
   exit 1
 fi
@@ -367,7 +370,7 @@ if [ -n "$TARGET_VERSION" ] && { [ -z "$READY_VERSION" ] || ! version_at_least "
   printf '[Better Codex] Installed version %s does not match target v%s. Installation failed.\n' "${READY_VERSION:-unknown}" "$TARGET_VERSION" >&2
   exit 1
 fi
-if ! printf '%s' ":$PATH:" | grep -q ":$BIN_DIR:"; then
+if [ "${BETTER_CODEX_SKIP_PATH_UPDATE:-0}" != "1" ] && ! printf '%s' ":$PATH:" | grep -q ":$BIN_DIR:"; then
   for RC in "$HOME/.zshrc" "$HOME/.bashrc"; do
     if [ -f "$RC" ] && ! grep -qF "$BIN_DIR" "$RC"; then
       printf '\nexport PATH="%s:$PATH"\n' "$BIN_DIR" >> "$RC"

--- a/scripts/refresh-injector.mjs
+++ b/scripts/refresh-injector.mjs
@@ -5,10 +5,10 @@ import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
-const betterCodexHome = resolve(process.env.BETTER_CODEX_HOME || join(homedir(), ".better-codex"));
+const betterCodexHome = resolve(process.env.BETTER_CODEX_DEV_HOME || join(homedir(), ".better-codex-dev"));
 const injectionStatePath = join(betterCodexHome, "run", "injection.json");
 const executable = join(root, "dist", "cli.js");
-const environment = { ...process.env, BETTER_CODEX_DISABLE_DELEGATION: "1" };
+const environment = { ...process.env, BETTER_CODEX_PROFILE: "development", BETTER_CODEX_HOME: betterCodexHome, BETTER_CODEX_DISABLE_DELEGATION: "1" };
 
 if (!existsSync(injectionStatePath)) process.exit(0);
 
@@ -31,10 +31,10 @@ try {
   process.exit(0);
 }
 
-if (!current?.injection?.available || !current.injection.targets?.length) process.exit(0);
+const runtimePort = Number(current?.runtime?.port);
+const expectedEndpoint = Number.isInteger(runtimePort) && runtimePort > 0 ? `http://127.0.0.1:${runtimePort}` : "";
+const ownsInjection = expectedEndpoint && current?.injection?.targets?.some(target => target.endpoint === expectedEndpoint);
+if (!current?.injection?.available || !ownsInjection) process.exit(0);
 
-const eject = spawnSync(process.execPath, [executable, "eject"], { stdio: "inherit", env: environment });
-if (eject.status !== 0) process.exit(eject.status ?? 1);
-
-const inject = spawnSync(process.execPath, [executable, "inject"], { stdio: "inherit", env: environment });
-process.exit(inject.status ?? 1);
+const refresh = spawnSync(process.execPath, [executable, "refresh-injection"], { stdio: "inherit", env: environment });
+process.exit(refresh.status ?? 1);

--- a/scripts/refresh-local-install.mjs
+++ b/scripts/refresh-local-install.mjs
@@ -1,37 +1,35 @@
 import { spawnSync } from "node:child_process";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const root = resolve(join(fileURLToPath(new URL(".", import.meta.url)), ".."));
-const home = resolve(process.env.BETTER_CODEX_HOME || join(homedir(), ".better-codex"));
+const home = resolve(process.env.BETTER_CODEX_DEV_HOME || join(homedir(), ".better-codex-dev"));
+const stableHome = resolve(process.env.BETTER_CODEX_STABLE_HOME || join(homedir(), ".better-codex"));
 const executable = join(root, "dist", "cli.js");
 const launchStatePath = join(home, "run", "launch-integration.json");
-const launchAgentPath = join(homedir(), "Library", "LaunchAgents", "com.better-codex.runtime.plist");
-const environment = { ...process.env, BETTER_CODEX_DISABLE_DELEGATION: "1" };
+const environment = { ...process.env, BETTER_CODEX_PROFILE: "development", BETTER_CODEX_HOME: home, BETTER_CODEX_PEER_HOME: stableHome, BETTER_CODEX_DISABLE_DELEGATION: "1" };
 
-if (!existsSync(launchStatePath) && !existsSync(launchAgentPath)) process.exit(0);
+if (!existsSync(launchStatePath)) process.exit(0);
 
-function run(args) {
-  const result = spawnSync(process.execPath, [executable, ...args], { encoding: "utf8", env: environment, stdio: "inherit" });
+function run(args, capture = false) {
+  const result = spawnSync(process.execPath, [executable, ...args], { encoding: "utf8", env: environment, stdio: capture ? "pipe" : "inherit" });
   if (result.error) throw result.error;
   if (result.status !== 0) process.exit(result.status ?? 1);
+  return capture ? result.stdout.trim() : "";
 }
 
-const serviceStatus = spawnSync(process.execPath, [executable, "service", "status"], { encoding: "utf8", env: environment });
-if (serviceStatus.status !== 0) process.exit(serviceStatus.status ?? 1);
-
-let service;
+run(["launcher", "install"]);
+let status;
 try {
-  service = JSON.parse(serviceStatus.stdout);
+  status = JSON.parse(run(["status"], true) || "{}");
 } catch {
   process.exit(1);
 }
-
-const serviceNeedsRefresh = process.platform !== "darwin"
-  || !existsSync(launchAgentPath)
-  || !readFileSync(launchAgentPath, "utf8").includes(executable);
-if (service.installed === true && serviceNeedsRefresh) run(["service", "install"]);
-else if (service.installed === true && service.running === true) run(["service", "restart"]);
-if (existsSync(launchStatePath)) run(["launcher", "install"]);
+if (status.runtime?.ok === true) {
+  const expectedEndpoint = `http://127.0.0.1:${status.runtime.port}`;
+  const ownsInjection = status.injection?.targets?.some(target => target.endpoint === expectedEndpoint) === true;
+  run(["stop"]);
+  if (ownsInjection) run(["start"]);
+}

--- a/scripts/test-local-install.mjs
+++ b/scripts/test-local-install.mjs
@@ -1,0 +1,79 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const packageJson = JSON.parse(readFileSync(join(root, "package.json"), "utf8"));
+const platform = process.platform === "darwin" ? "darwin" : process.platform;
+const architecture = process.arch === "x64" ? "amd64" : process.arch;
+
+if (![["darwin", "arm64"], ["darwin", "amd64"], ["win32", "amd64"]].some(([os, arch]) => os === platform && arch === architecture)) {
+  throw new Error(`local_install_test_unsupported:${platform}-${architecture}`);
+}
+
+const releaseDirectory = join(root, "release");
+const extension = platform === "win32" ? "zip" : "tar.gz";
+const archive = join(releaseDirectory, `better-codex-cli-${packageJson.version}-${platform}-${architecture}.${extension}`);
+const checksums = join(releaseDirectory, "checksums.txt");
+if (!existsSync(archive)) throw new Error(`local_install_archive_missing:${archive}`);
+if (!existsSync(checksums)) throw new Error(`local_install_checksums_missing:${checksums}`);
+
+const testRoot = await mkdtemp(join(tmpdir(), "better-codex-local-install-"));
+const userHome = join(testRoot, "user");
+const codexHome = join(testRoot, "codex");
+const betterCodexHome = join(testRoot, "better-codex");
+const binDirectory = join(testRoot, "bin");
+const executable = join(binDirectory, platform === "win32" ? "better-codex.exe" : "better-codex");
+const environment = {
+  ...process.env,
+  BETTER_CODEX_ARCHIVE: archive,
+  BETTER_CODEX_CHECKSUMS: checksums,
+  BETTER_CODEX_DISABLE_DELEGATION: "1",
+  BETTER_CODEX_HOME: betterCodexHome,
+  BETTER_CODEX_SKIP_PATH_UPDATE: "1",
+  CODEX_HOME: codexHome,
+  HOME: userHome,
+  USERPROFILE: userHome,
+};
+for (const key of Object.keys(environment)) {
+  if (key.toLowerCase() === "psmodulepath") delete environment[key];
+}
+
+function install() {
+  if (platform === "win32") {
+    execFileSync("powershell.exe", [
+      "-NoProfile",
+      "-NonInteractive",
+      "-ExecutionPolicy", "Bypass",
+      "-File", join(root, "scripts", "install.ps1"),
+      "-Repository", "invalid/local-install-must-not-download",
+      "-BinDirectory", binDirectory,
+      "-NoService",
+    ], { env: environment, stdio: "inherit" });
+    return;
+  }
+  execFileSync("/bin/bash", [join(root, "scripts", "install.sh"), "--no-service"], {
+    env: { ...environment, BETTER_CODEX_BIN_DIR: binDirectory, BETTER_CODEX_REPO: "invalid/local-install-must-not-download" },
+    stdio: "inherit",
+  });
+}
+
+try {
+  install();
+  install();
+  if (!existsSync(executable)) throw new Error("local_install_executable_missing");
+  if (!existsSync(join(codexHome, "skills", "better-codex", "SKILL.md"))) throw new Error("local_install_skill_missing");
+  if (!existsSync(join(betterCodexHome, "update-public-key.pem"))) throw new Error("local_install_update_key_missing");
+
+  const output = execFileSync(executable, ["version", "--json"], { encoding: "utf8", env: environment });
+  const versions = JSON.parse(output);
+  if (versions.core !== packageJson.version) {
+    throw new Error(`local_install_version_mismatch:expected=${packageJson.version}:actual=${versions.core ?? "unknown"}`);
+  }
+  console.log(JSON.stringify({ installed: true, reinstalled: true, platform, architecture, version: versions.core }));
+} finally {
+  await rm(testRoot, { recursive: true, force: true });
+}

--- a/src/cdp.ts
+++ b/src/cdp.ts
@@ -2,7 +2,9 @@ import { execFileSync, spawn } from "node:child_process";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { activeCompatibility, capabilityExpression, clearCompatibilityStatus, missingCapabilities, navigationExpression, readCompatibilityStatus, targetAllowed, type RendererCapabilities, writeCompatibilityStatus } from "./compatibility.js";
+import { betterCodexProfile } from "./config.js";
 import { injectionScript, injectionVersion } from "./dom.js";
+import { recordInjectionOwnership, setInjectionEnabled } from "./injection-state.js";
 import { readCodexLocale } from "./locale.js";
 import { showNativeChoiceDialog } from "./native-dialog.js";
 import { readRuntimeState } from "./runtime-state.js";
@@ -31,8 +33,14 @@ class Connection {
 
   open() {
     return new Promise<void>((resolve, reject) => {
-      this.socket.addEventListener("open", () => resolve(), { once: true });
-      this.socket.addEventListener("error", () => reject(new Error("cdp_websocket_error")), { once: true });
+      const cleanup = () => {
+        this.socket.removeEventListener("open", onOpen);
+        this.socket.removeEventListener("error", onError);
+      };
+      const onOpen = () => { cleanup(); resolve(); };
+      const onError = () => { cleanup(); reject(new Error("cdp_websocket_error")); };
+      this.socket.addEventListener("open", onOpen, { once: true });
+      this.socket.addEventListener("error", onError, { once: true });
     });
   }
 
@@ -67,8 +75,19 @@ class Connection {
     return () => this.socket.removeEventListener("close", listener);
   }
 
-  close() {
-    this.socket.close();
+  async close() {
+    if (this.socket.readyState === WebSocket.CLOSED) return;
+    const closed = new Promise<void>(resolve => {
+      this.socket.addEventListener("close", () => resolve(), { once: true });
+      this.socket.addEventListener("error", () => resolve(), { once: true });
+    });
+    try {
+      if (this.socket.readyState !== WebSocket.CLOSING) this.socket.close();
+    } catch {
+      return;
+    }
+    await Promise.race([closed, new Promise<void>(resolve => setTimeout(resolve, 500))]);
+    await new Promise<void>(resolve => setTimeout(resolve, 100));
   }
 }
 
@@ -158,7 +177,7 @@ async function mainTargets(port: number, options: { trustIds?: Set<string> } = {
       lastTargetId = target.id;
       lastCapabilities = null;
     } finally {
-      connection.close();
+      await connection.close();
     }
   }
   if (selected.length > 0) {
@@ -399,8 +418,12 @@ async function installTarget(target: Target, runtimePort: number, accessToken: s
     await connection.send("Page.setBypassCSP", { enabled: true });
     await connection.send("Runtime.enable");
     try { await connection.send("Runtime.addBinding", { name: "betterCodexRequest" }); } catch {}
-    const existing = await evaluate(connection, "({ version: window.__betterCodexInjection__?.version || null, endpoint: window.__betterCodexInjection__?.endpoint || null })") as { version?: string; endpoint?: string };
-    if (existing.version === injectionVersion() && existing.endpoint === `http://127.0.0.1:${runtimePort}`) {
+    const existing = await evaluate(connection, "({ version: window.__betterCodexInjection__?.version || null, profile: window.__betterCodexInjection__?.profile || null, endpoint: window.__betterCodexInjection__?.endpoint || null })") as { version?: string; profile?: string; endpoint?: string };
+    const expectedEndpoint = `http://127.0.0.1:${runtimePort}`;
+    const foreignDevelopmentInjection = betterCodexProfile === "development"
+      && ((existing.profile && existing.profile !== betterCodexProfile) || (!existing.profile && existing.endpoint && existing.endpoint !== expectedEndpoint));
+    if (foreignDevelopmentInjection) throw new Error("profile_not_active");
+    if (existing.version === injectionVersion() && existing.profile === betterCodexProfile && existing.endpoint === expectedEndpoint) {
       const storedIdentifier = await evaluate(connection, "window.__betterCodexNewDocumentScriptId || null");
       await evaluate(connection, "window.__betterCodexInjection__.refresh()");
       const current = readCompatibilityStatus();
@@ -416,16 +439,25 @@ async function installTarget(target: Target, runtimePort: number, accessToken: s
     writeCompatibilityStatus({ codexVersion: current?.codexVersion ?? desktopVersion(), compatible: true, reason: null, targetId: target.id, capabilities: current?.capabilities ?? null }, true);
     return { targetId: target.id, title: target.title, installed: true, reused: false, identifier };
   } finally {
-    connection.close();
+    await connection.close();
   }
 }
 
-async function uninstallTarget(target: Target, accessToken: string) {
+type InjectionOwnership = { profile: string; endpoint?: string; allowLegacyProfileless?: boolean };
+
+async function uninstallTarget(target: Target, accessToken: string, ownership?: InjectionOwnership) {
   const connection = new Connection(target.webSocketDebuggerUrl!);
   await connection.open();
   try {
     await connection.send("Page.enable");
     await connection.send("Runtime.enable");
+    const existing = await evaluate(connection, "({ profile: window.__betterCodexInjection__?.profile || null, endpoint: window.__betterCodexInjection__?.endpoint || null })") as { profile?: string; endpoint?: string };
+    if (ownership) {
+      const owned = existing.profile
+        ? existing.profile === ownership.profile
+        : Boolean(ownership.allowLegacyProfileless || (ownership.endpoint && existing.endpoint === ownership.endpoint));
+      if (!owned) return { targetId: target.id, title: target.title, uninstalled: false, reason: "profile_not_active" };
+    }
     const stored = await evaluate(connection, "window.__betterCodexNewDocumentScriptId || null");
     const scriptIdentifier = typeof stored === "string" ? stored : "";
     if (scriptIdentifier) {
@@ -437,7 +469,7 @@ async function uninstallTarget(target: Target, accessToken: string) {
     const value = await evaluate(connection, injectionScript(0, accessToken, "uninstall"));
     return { targetId: target.id, title: target.title, uninstalled: true, value };
   } finally {
-    connection.close();
+    await connection.close();
   }
 }
 
@@ -458,7 +490,9 @@ export async function cdpInject(port: number, runtimePort: number, accessToken: 
     values = await waitForTargets(port);
   }
   if (values.length === 0) throw new Error("cdp_main_renderer_not_found");
-  return Promise.all(values.map(target => installTarget(target, runtimePort, accessToken)));
+  const installed = await Promise.all(values.map(target => installTarget(target, runtimePort, accessToken)));
+  recordInjectionOwnership(betterCodexProfile, `http://127.0.0.1:${runtimePort}`);
+  return installed;
 }
 
 export async function cdpRestartAndInject(port: number, runtimePort: number, accessToken: string, options: { confirmQuit?: boolean } = {}) {
@@ -468,10 +502,10 @@ export async function cdpRestartAndInject(port: number, runtimePort: number, acc
   return cdpInject(port, runtimePort, accessToken, true);
 }
 
-export async function cdpEject(port: number, accessToken: string) {
+export async function cdpEject(port: number, accessToken: string, ownership?: InjectionOwnership) {
   try {
     const values = await targets(port);
-    return await Promise.all(values.map(target => uninstallTarget(target, accessToken)));
+    return await Promise.all(values.map(target => uninstallTarget(target, accessToken, ownership)));
   } finally {
     clearCompatibilityStatus();
   }
@@ -487,13 +521,15 @@ export async function cdpStatus(port: number) {
       try {
         const value = await evaluate(connection, `({
           version: window.__betterCodexInjection__?.version || null,
+          profile: window.__betterCodexInjection__?.profile || null,
+          endpoint: window.__betterCodexInjection__?.endpoint || null,
           entry: Boolean(document.getElementById('better-codex-entry')),
           panel: Boolean(document.getElementById('better-codex-panel')),
           open: document.documentElement.hasAttribute('data-better-codex-open')
         })`);
         rendered.push({ targetId: target.id, title: target.title, url: target.url, ...(value as object) });
       } finally {
-        connection.close();
+        await connection.close();
       }
     }
     return { available: true, port, compatibility: readCompatibilityStatus(), targets: rendered };
@@ -511,7 +547,7 @@ export async function cdpOpenThread(port: number, threadId: string) {
   try {
     return await evaluate(connection, navigationExpression(threadId));
   } finally {
-    connection.close();
+    await connection.close();
   }
 }
 
@@ -519,6 +555,7 @@ export async function watchInjection(port: number, accessToken: string) {
   const attached = new Map<string, { connection: Connection; identifier?: string; target: Target }>();
   let activeRuntimePort = 0;
   let stopping = false;
+  let yieldedToPeer = false;
   let discovery: Connection | null = null;
   let wakeTargetActivity: (() => void) | null = null;
   const wake = () => {
@@ -544,7 +581,7 @@ export async function watchInjection(port: number, accessToken: string) {
       await connection.send("Target.setDiscoverTargets", { discover: true });
       discovery = connection;
     } catch {
-      connection?.close();
+      await connection?.close();
     }
   };
   const targetActivity = () => new Promise<void>(resolve => {
@@ -571,7 +608,7 @@ export async function watchInjection(port: number, accessToken: string) {
             await evaluate(current.connection, injectionScript(0, accessToken, "uninstall"));
           } catch {
           }
-          current.connection.close();
+          await current.connection.close();
         }
         attached.clear();
       }
@@ -580,54 +617,76 @@ export async function watchInjection(port: number, accessToken: string) {
       const activeIds = new Set(values.map(target => target.id));
       for (const [id, current] of attached) {
         if (!activeIds.has(id)) {
-          current.connection.close();
+          await current.connection.close();
           attached.delete(id);
         }
       }
       for (const target of values) {
         if (attached.has(target.id)) continue;
         const connection = new Connection(target.webSocketDebuggerUrl!);
-        await connection.open();
-        await connection.send("Page.enable");
-        await connection.send("Page.setBypassCSP", { enabled: true });
-        await connection.send("Runtime.enable");
-        try { await connection.send("Runtime.addBinding", { name: "betterCodexRequest" }); } catch {}
-        connection.on("Runtime.bindingCalled", params => {
-          if (params.name === "betterCodexRequest") void bridgeRequest(connection, activeRuntimePort, accessToken, params.payload);
-        });
-        const existing = await evaluate(connection, "({ version: window.__betterCodexInjection__?.version || null, endpoint: window.__betterCodexInjection__?.endpoint || null })") as { version?: string; endpoint?: string };
-        let identifier: string | undefined;
-        if (existing.version === injectionVersion() && existing.endpoint === `http://127.0.0.1:${activeRuntimePort}`) {
-          const stored = await evaluate(connection, "window.__betterCodexNewDocumentScriptId || null");
-          identifier = typeof stored === "string" ? stored : undefined;
-          await evaluate(connection, "window.__betterCodexInjection__.refresh()");
-        } else {
-          const source = injectionScript(activeRuntimePort, accessToken, "install", readCodexLocale());
-          const registration = await connection.send("Page.addScriptToEvaluateOnNewDocument", { source });
-          identifier = String(registration.identifier ?? "") || undefined;
-          await evaluate(connection, source);
-          await evaluate(connection, `window.__betterCodexNewDocumentScriptId = ${JSON.stringify(identifier ?? "")}`);
+        let transferred = false;
+        try {
+          await connection.open();
+          await connection.send("Page.enable");
+          await connection.send("Page.setBypassCSP", { enabled: true });
+          await connection.send("Runtime.enable");
+          try { await connection.send("Runtime.addBinding", { name: "betterCodexRequest" }); } catch {}
+          connection.on("Runtime.bindingCalled", params => {
+            if (params.name === "betterCodexRequest") void bridgeRequest(connection, activeRuntimePort, accessToken, params.payload);
+          });
+          const existing = await evaluate(connection, "({ version: window.__betterCodexInjection__?.version || null, profile: window.__betterCodexInjection__?.profile || null, endpoint: window.__betterCodexInjection__?.endpoint || null })") as { version?: string; profile?: string; endpoint?: string };
+          const expectedEndpoint = `http://127.0.0.1:${activeRuntimePort}`;
+          if (betterCodexProfile === "development" && (existing.profile ? existing.profile !== betterCodexProfile : Boolean(existing.endpoint && existing.endpoint !== expectedEndpoint))) {
+            setInjectionEnabled(false);
+            stopping = true;
+            yieldedToPeer = true;
+            break;
+          }
+          let identifier: string | undefined;
+          if (existing.version === injectionVersion() && existing.profile === betterCodexProfile && existing.endpoint === expectedEndpoint) {
+            const stored = await evaluate(connection, "window.__betterCodexNewDocumentScriptId || null");
+            identifier = typeof stored === "string" ? stored : undefined;
+            await evaluate(connection, "window.__betterCodexInjection__.refresh()");
+          } else {
+            const source = injectionScript(activeRuntimePort, accessToken, "install", readCodexLocale());
+            const registration = await connection.send("Page.addScriptToEvaluateOnNewDocument", { source });
+            identifier = String(registration.identifier ?? "") || undefined;
+            await evaluate(connection, source);
+            await evaluate(connection, `window.__betterCodexNewDocumentScriptId = ${JSON.stringify(identifier ?? "")}`);
+          }
+          attached.set(target.id, { connection, identifier, target });
+          transferred = true;
+          recordInjectionOwnership(betterCodexProfile, expectedEndpoint);
+          const current = readCompatibilityStatus();
+          writeCompatibilityStatus({ codexVersion: current?.codexVersion ?? desktopVersion(), compatible: true, reason: null, targetId: target.id, capabilities: current?.capabilities ?? null }, true);
+        } finally {
+          if (!transferred) await connection.close();
         }
-        attached.set(target.id, { connection, identifier, target });
-        const current = readCompatibilityStatus();
-        writeCompatibilityStatus({ codexVersion: current?.codexVersion ?? desktopVersion(), compatible: true, reason: null, targetId: target.id, capabilities: current?.capabilities ?? null }, true);
       }
+      if (stopping) break;
       // Health-check attached sessions without opening a second debugger to the same target.
       for (const [id, current] of attached) {
         try {
-          const existing = await evaluate(current.connection, "({ version: window.__betterCodexInjection__?.version || null, endpoint: window.__betterCodexInjection__?.endpoint || null })") as { version?: string; endpoint?: string };
-          if (existing.version !== injectionVersion() || existing.endpoint !== `http://127.0.0.1:${activeRuntimePort}`) {
+          const existing = await evaluate(current.connection, "({ version: window.__betterCodexInjection__?.version || null, profile: window.__betterCodexInjection__?.profile || null, endpoint: window.__betterCodexInjection__?.endpoint || null })") as { version?: string; profile?: string; endpoint?: string };
+          if (betterCodexProfile === "development" && (existing.profile ? existing.profile !== betterCodexProfile : Boolean(existing.endpoint && existing.endpoint !== `http://127.0.0.1:${activeRuntimePort}`))) {
+            setInjectionEnabled(false);
+            stopping = true;
+            yieldedToPeer = true;
+            break;
+          }
+          if (existing.version !== injectionVersion() || existing.profile !== betterCodexProfile || existing.endpoint !== `http://127.0.0.1:${activeRuntimePort}`) {
             if (current.identifier) {
               try { await current.connection.send("Page.removeScriptToEvaluateOnNewDocument", { identifier: current.identifier }); } catch {}
             }
-            current.connection.close();
+            await current.connection.close();
             attached.delete(id);
           }
         } catch {
-          current.connection.close();
+          await current.connection.close();
           attached.delete(id);
         }
       }
+      if (stopping) break;
       settleMs = attached.size > 0 ? 2500 : 250;
     } catch (error) {
       const message = error instanceof Error ? error.message : "injector_cycle_failed";
@@ -639,13 +698,19 @@ export async function watchInjection(port: number, accessToken: string) {
     wake();
   }
   const activeDiscovery = discovery as Connection | null;
-  activeDiscovery?.close();
+  await activeDiscovery?.close();
   for (const current of attached.values()) {
     try {
       if (current.identifier) await current.connection.send("Page.removeScriptToEvaluateOnNewDocument", { identifier: current.identifier });
-      await evaluate(current.connection, injectionScript(0, accessToken, "uninstall"));
+      if (!yieldedToPeer) await evaluate(current.connection, injectionScript(0, accessToken, "uninstall"));
     } catch {
     }
-    current.connection.close();
+    await current.connection.close();
   }
+}
+
+export async function closeCdpConnectionForTest(url: string) {
+  const connection = new Connection(url);
+  await connection.open();
+  await connection.close();
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { execFileSync, spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { accessSync, closeSync, constants, cpSync, existsSync, mkdirSync, openSync, readFileSync, realpathSync, renameSync, rmSync, statSync, unlinkSync, writeFileSync } from "node:fs";
+import { accessSync, closeSync, constants, cpSync, existsSync, mkdirSync, openSync, readFileSync, readdirSync, realpathSync, renameSync, rmSync, statSync, unlinkSync, utimesSync, writeFileSync } from "node:fs";
 import { isSea } from "node:sea";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
@@ -16,9 +16,12 @@ import {
   injectorLogPath,
   injectorPidPath,
   betterCodexHome,
+  betterCodexProfile,
+  launchIntentPath,
   launchLockPath,
   logPath,
   managedRuntimePath,
+  peerBetterCodexHome,
   runPath,
   runtimeLogPath,
   updatePublicKeyPath,
@@ -29,7 +32,6 @@ import { injectionEnabled, setInjectionEnabled } from "./injection-state.js";
 import { installLaunchIntegration, launchIntegrationStatus, uninstallLaunchIntegration } from "./launch-integration.js";
 import { readCodexLocale } from "./locale.js";
 import { betterCodexMcpName, startMcpAppServer } from "./mcp-app.js";
-import { showNativeChoiceDialog } from "./native-dialog.js";
 import { installService, restartService, serviceLogs, serviceStatus, startService, stopService, uninstallService } from "./service.js";
 import { activeVersions, checkForUpdates, maybeDelegateToActiveCore, recordGatewayUpdateActivation, rollbackCompatibilityUpdate, rollbackCoreUpdate, updateAll, updateCompatibility } from "./updater.js";
 
@@ -133,7 +135,7 @@ async function ensureRuntime() {
   try {
     return await health();
   } catch {
-    if (serviceStatus().installed) startService();
+    if (betterCodexProfile === "stable" && serviceStatus().installed) startService();
     else spawnSelf(["runtime"], runtimeLogPath);
     for (let attempt = 0; attempt < 60; attempt += 1) {
       try {
@@ -144,19 +146,6 @@ async function ensureRuntime() {
     }
     throw new Error("runtime_start_failed");
   }
-}
-
-function confirmLaunchRestart() {
-  const chinese = readCodexLocale() === "zh-CN";
-  const message = chinese
-    ? "当前进程正在运行。\n\n请选择操作。"
-    : "The current process is already running.\n\nChoose an action.";
-  return showNativeChoiceDialog({
-    message,
-    title: "Better Codex",
-    primaryLabel: chinese ? "重启进程" : "Restart process",
-    secondaryLabel: chinese ? "直接打开" : "Open directly",
-  });
 }
 
 async function restartRuntime() {
@@ -183,6 +172,15 @@ function activeRuntimePort() {
   return runtime.port;
 }
 
+function injectionOwnership(profile = betterCodexProfile, stateRunPath = runPath, allowLegacyProfileless = false) {
+  const runtime = readJsonFile<{ port?: unknown }>(join(stateRunPath, "runtime.json"));
+  const injection = readJsonFile<{ endpoint?: unknown }>(join(stateRunPath, "injection.json"));
+  const runtimePort = Number(runtime?.port);
+  const recordedEndpoint = typeof injection?.endpoint === "string" ? injection.endpoint : "";
+  const expectedEndpoint = Number.isInteger(runtimePort) && runtimePort > 0 ? `http://127.0.0.1:${runtimePort}` : recordedEndpoint;
+  return { profile, ...(expectedEndpoint ? { endpoint: expectedEndpoint } : {}), ...(allowLegacyProfileless ? { allowLegacyProfileless: true } : {}) };
+}
+
 function processAlive(pid: number) {
   try {
     process.kill(pid, 0);
@@ -192,17 +190,31 @@ function processAlive(pid: number) {
   }
 }
 
-function isInjectorProcess(pid: number) {
+function processCommandLine(pid: number) {
   try {
     if (process.platform === "win32") {
-      const commandLine = execFileSync("powershell.exe", ["-NoProfile", "-NonInteractive", "-Command", `(Get-CimInstance Win32_Process -Filter \"ProcessId = ${pid}\").CommandLine`], { encoding: "utf8", windowsHide: true }).trim();
-      return /\bwatch-inject\b/.test(commandLine);
+      return execFileSync("powershell.exe", ["-NoProfile", "-NonInteractive", "-Command", `(Get-CimInstance Win32_Process -Filter \"ProcessId = ${pid}\").CommandLine`], { encoding: "utf8", windowsHide: true }).trim();
     }
-    const commandLine = execFileSync("ps", ["-p", String(pid), "-o", "command="], { encoding: "utf8" }).trim();
-    return /\bwatch-inject\b/.test(commandLine);
+    return execFileSync("ps", ["-p", String(pid), "-o", "command="], { encoding: "utf8" }).trim();
   } catch {
-    return false;
+    return "";
   }
+}
+
+function processStartTime(pid: number) {
+  try {
+    const value = process.platform === "win32"
+      ? execFileSync("powershell.exe", ["-NoProfile", "-NonInteractive", "-Command", `$process = Get-CimInstance Win32_Process -Filter \"ProcessId = ${pid}\"; if ($process) { $process.CreationDate.ToUniversalTime().ToString('o') }`], { encoding: "utf8", windowsHide: true }).trim()
+      : execFileSync("ps", ["-p", String(pid), "-o", "lstart="], { encoding: "utf8" }).trim();
+    const parsed = Date.parse(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function isInjectorProcess(pid: number) {
+  return /\bwatch-inject\b/.test(processCommandLine(pid));
 }
 
 function injectorPid() {
@@ -303,12 +315,12 @@ async function withLaunchLock<T>(operation: () => Promise<T>) {
   ensureDirectories();
   const token = randomUUID();
   let acquired = false;
-  for (let attempt = 0; attempt < 100; attempt += 1) {
+  for (let attempt = 0; attempt < 600; attempt += 1) {
     let created = false;
     try {
       mkdirSync(launchLockPath, { mode: 0o700 });
       created = true;
-      writeFileSync(join(launchLockPath, "owner.json"), JSON.stringify({ pid: process.pid, token }), { mode: 0o600 });
+      writeFileSync(join(launchLockPath, "owner.json"), JSON.stringify({ pid: process.pid, token, processStartedAt: new Date(processStartTime(process.pid) ?? Date.now()).toISOString() }), { mode: 0o600 });
       acquired = true;
       break;
     } catch (error) {
@@ -316,12 +328,14 @@ async function withLaunchLock<T>(operation: () => Promise<T>) {
         rmSync(launchLockPath, { recursive: true, force: true });
         throw error;
       }
-      let owner: { pid?: number } | null = null;
-      try { owner = JSON.parse(readFileSync(join(launchLockPath, "owner.json"), "utf8")) as { pid?: number }; } catch {}
-      let stale = Boolean(owner?.pid && !processAlive(owner.pid));
-      if (!owner?.pid) {
-        try { stale = Date.now() - statSync(launchLockPath).mtimeMs > 30_000; } catch {}
-      }
+      let owner: { pid?: number; processStartedAt?: string } | null = null;
+      try { owner = JSON.parse(readFileSync(join(launchLockPath, "owner.json"), "utf8")) as { pid?: number; processStartedAt?: string }; } catch {}
+      let leaseExpired = false;
+      try { leaseExpired = Date.now() - statSync(launchLockPath).mtimeMs > 15_000; } catch {}
+      const expectedStart = owner?.processStartedAt ? Date.parse(owner.processStartedAt) : NaN;
+      const observedStart = owner?.pid && processAlive(owner.pid) ? processStartTime(owner.pid) : null;
+      const identityMismatch = Number.isFinite(expectedStart) && observedStart !== null && Math.abs(expectedStart - observedStart) > 1500;
+      const stale = Boolean(owner?.pid && (!processAlive(owner.pid) || identityMismatch)) || Boolean(leaseExpired && (!owner?.pid || !owner.processStartedAt));
       if (stale) {
         const stalePath = `${launchLockPath}.stale.${token}`;
         try {
@@ -334,9 +348,14 @@ async function withLaunchLock<T>(operation: () => Promise<T>) {
     }
   }
   if (!acquired) throw new Error("codex_launch_busy");
+  const heartbeat = setInterval(() => {
+    try { utimesSync(launchLockPath, new Date(), new Date()); } catch {}
+  }, 1000);
+  heartbeat.unref();
   try {
     return await operation();
   } finally {
+    clearInterval(heartbeat);
     try {
       const owner = JSON.parse(readFileSync(join(launchLockPath, "owner.json"), "utf8")) as { token?: string };
       if (owner.token === token) {
@@ -351,12 +370,254 @@ async function withLaunchLock<T>(operation: () => Promise<T>) {
 async function stopInjector() {
   const pid = injectorPid();
   if (pid) {
-    process.kill(pid, "SIGTERM");
-    for (let attempt = 0; attempt < 30 && processAlive(pid); attempt += 1) {
+    try { process.kill(pid, "SIGTERM"); } catch (error) { if (processAlive(pid)) throw error; }
+    for (let attempt = 0; attempt < 90 && processAlive(pid); attempt += 1) {
       await new Promise(resolve => setTimeout(resolve, 100));
     }
+    if (processAlive(pid) && isInjectorProcess(pid)) {
+      try { process.kill(pid, "SIGKILL"); } catch (error) { if (processAlive(pid)) throw error; }
+      for (let attempt = 0; attempt < 10 && processAlive(pid); attempt += 1) await new Promise(resolve => setTimeout(resolve, 100));
+    }
+    if (processAlive(pid)) throw new Error("injector_stop_failed");
   }
-  if (existsSync(injectorPidPath)) unlinkSync(injectorPidPath);
+  if (existsSync(injectorPidPath)) {
+    const recorded = Number(readFileSync(injectorPidPath, "utf8"));
+    if (!Number.isInteger(recorded) || recorded === pid || !processAlive(recorded) || !isInjectorProcess(recorded)) unlinkSync(injectorPidPath);
+  }
+}
+
+async function nextLaunchIntentSequence() {
+  mkdirSync(launchIntentPath, { recursive: true, mode: 0o700 });
+  const lockPath = join(launchIntentPath, "sequence.lock");
+  const counterPath = join(launchIntentPath, "sequence");
+  const ownerToken = randomUUID();
+  for (let attempt = 0; attempt < 500; attempt += 1) {
+    try {
+      mkdirSync(lockPath, { mode: 0o700 });
+      writeFileSync(join(lockPath, "owner.json"), JSON.stringify({ pid: process.pid, token: ownerToken, processStartedAt: new Date(processStartTime(process.pid) ?? Date.now()).toISOString() }), { mode: 0o600 });
+      try {
+        const current = Number(existsSync(counterPath) ? readFileSync(counterPath, "utf8") : "0");
+        const sequence = Number.isSafeInteger(current) && current >= 0 ? current + 1 : 1;
+        const temporary = `${counterPath}.${process.pid}.tmp`;
+        writeFileSync(temporary, String(sequence), { mode: 0o600 });
+        renameSync(temporary, counterPath);
+        return sequence;
+      } finally {
+        const owner = readJsonFile<{ token?: string }>(join(lockPath, "owner.json"));
+        if (owner?.token === ownerToken) rmSync(lockPath, { recursive: true, force: true });
+      }
+    } catch {
+      const owner = readJsonFile<{ pid?: number; processStartedAt?: string }>(join(lockPath, "owner.json"));
+      try {
+        const expectedStart = owner?.processStartedAt ? Date.parse(owner.processStartedAt) : NaN;
+        const observedStart = owner?.pid && processAlive(owner.pid) ? processStartTime(owner.pid) : null;
+        const identityMismatch = Number.isFinite(expectedStart) && observedStart !== null && Math.abs(expectedStart - observedStart) > 1500;
+        const ownerGone = Boolean(owner?.pid && (!processAlive(owner.pid) || identityMismatch));
+        const ownerMissingAndStale = !owner?.pid && Date.now() - statSync(lockPath).mtimeMs > 5000;
+        if (ownerGone || ownerMissingAndStale) {
+          const stalePath = `${lockPath}.stale.${ownerToken}`;
+          renameSync(lockPath, stalePath);
+          rmSync(stalePath, { recursive: true, force: true });
+        }
+      } catch {}
+      await new Promise(resolve => setTimeout(resolve, 10));
+    }
+  }
+  throw new Error("launch_intent_busy");
+}
+
+async function recordLaunchIntent(restart: boolean) {
+  const intent = { token: randomUUID(), sequence: await nextLaunchIntentSequence(), profile: betterCodexProfile, restart, requestedAt: new Date().toISOString() };
+  writeFileSync(join(launchIntentPath, `${intent.token}.json`), JSON.stringify(intent), { mode: 0o600 });
+  return intent;
+}
+
+function latestLaunchIntent() {
+  const processed = Number(existsSync(join(launchIntentPath, "processed")) ? readFileSync(join(launchIntentPath, "processed"), "utf8") : "0");
+  const intents = existsSync(launchIntentPath)
+    ? readdirSync(launchIntentPath).filter(name => name.endsWith(".json")).map(name => readJsonFile<{ token?: string; sequence?: number; profile?: string; restart?: boolean }>(join(launchIntentPath, name))).filter(value => value?.token && Number.isSafeInteger(value.sequence))
+    : [];
+  return intents.filter(intent => intent!.sequence! > processed).sort((left, right) => right!.sequence! - left!.sequence!)[0] ?? null;
+}
+
+function markLaunchIntentProcessed(sequence: number) {
+  const path = join(launchIntentPath, "processed");
+  const temporary = `${path}.${process.pid}.tmp`;
+  writeFileSync(temporary, String(sequence), { mode: 0o600 });
+  renameSync(temporary, path);
+  for (const name of readdirSync(launchIntentPath)) {
+    if (!name.endsWith(".json")) continue;
+    const intent = readJsonFile<{ sequence?: number }>(join(launchIntentPath, name));
+    if (Number.isSafeInteger(intent?.sequence) && intent!.sequence! <= sequence) try { unlinkSync(join(launchIntentPath, name)); } catch {}
+  }
+}
+
+type PeerRuntimeState = {
+  pid: number;
+  port: number;
+  instanceId: string;
+  startedAt?: string;
+  processStartedAt?: string;
+};
+
+function readJsonFile<T>(path: string): T | null {
+  try {
+    return JSON.parse(readFileSync(path, "utf8")) as T;
+  } catch {
+    return null;
+  }
+}
+
+function peerInjectorPid(peerRunPath: string) {
+  const path = join(peerRunPath, "injector.pid");
+  const pid = Number(existsSync(path) ? readFileSync(path, "utf8") : "");
+  return Number.isInteger(pid) && processAlive(pid) && isInjectorProcess(pid) ? pid : null;
+}
+
+function peerRuntimeState(peerRunPath: string) {
+  const value = readJsonFile<Partial<PeerRuntimeState>>(join(peerRunPath, "runtime.json"));
+  if (!value || !Number.isInteger(value.pid) || !Number.isInteger(value.port) || typeof value.instanceId !== "string") return null;
+  if (!processAlive(value.pid!)) return null;
+  if (typeof value.processStartedAt === "string" || typeof value.startedAt === "string") {
+    const expectedStart = Date.parse(value.processStartedAt ?? value.startedAt!);
+    const observedStart = processStartTime(value.pid!);
+    const tolerance = value.processStartedAt ? 1500 : 30_000;
+    if (Number.isFinite(expectedStart) && observedStart !== null && Math.abs(expectedStart - observedStart) > tolerance) return null;
+  }
+  return value as PeerRuntimeState;
+}
+
+async function disablePeerInjection(peerRunPath: string) {
+  mkdirSync(peerRunPath, { recursive: true });
+  const path = join(peerRunPath, "injection.json");
+  const temporary = `${path}.${process.pid}.tmp`;
+  const current = readJsonFile<Record<string, unknown>>(path) ?? {};
+  writeFileSync(temporary, JSON.stringify({ ...current, enabled: false }), { mode: 0o600 });
+  try {
+    renameSync(temporary, path);
+  } catch {
+    try { unlinkSync(temporary); } catch {}
+    writeFileSync(path, JSON.stringify({ ...current, enabled: false }), { mode: 0o600 });
+  }
+}
+
+async function stopPeerInjector(peerRunPath: string) {
+  const path = join(peerRunPath, "injector.pid");
+  const pid = peerInjectorPid(peerRunPath);
+  if (pid) {
+    try { process.kill(pid, "SIGTERM"); } catch (error) { if (processAlive(pid)) throw error; }
+    for (let attempt = 0; attempt < 90 && processAlive(pid); attempt += 1) {
+      await new Promise(resolve => setTimeout(resolve, 100));
+    }
+    if (processAlive(pid) && isInjectorProcess(pid)) {
+      try { process.kill(pid, "SIGKILL"); } catch (error) { if (processAlive(pid)) throw error; }
+      for (let attempt = 0; attempt < 10 && processAlive(pid); attempt += 1) await new Promise(resolve => setTimeout(resolve, 100));
+    }
+  }
+  if (existsSync(path)) {
+    const recorded = Number(readFileSync(path, "utf8"));
+    if (!Number.isInteger(recorded) || !processAlive(recorded)) unlinkSync(path);
+  }
+  return Boolean(pid && !processAlive(pid));
+}
+
+async function stopPeerRuntime(peerHome: string, runtime: PeerRuntimeState | null) {
+  if (!runtime) return false;
+  if (!processAlive(runtime.pid)) return true;
+  const matchesRuntime = async () => {
+    try {
+      const response = await fetch(`http://127.0.0.1:${runtime.port}/health`, { signal: AbortSignal.timeout(750) });
+      const value = await response.json() as { pid?: number; instanceId?: string };
+      return response.ok && value.pid === runtime.pid && value.instanceId === runtime.instanceId;
+    } catch {
+      return false;
+    }
+  };
+  const verified = await matchesRuntime();
+  if (!processAlive(runtime.pid)) return true;
+  if (!verified) return false;
+  try {
+    const peerToken = readFileSync(join(peerHome, "run", "token"), "utf8").trim();
+    await fetch(`http://127.0.0.1:${runtime.port}/api/shutdown`, {
+      method: "POST",
+      signal: AbortSignal.timeout(1500),
+      headers: { authorization: `Bearer ${peerToken}` },
+    });
+  } catch {}
+  for (let attempt = 0; attempt < 30 && processAlive(runtime.pid); attempt += 1) {
+    await new Promise(resolve => setTimeout(resolve, 100));
+  }
+  if (processAlive(runtime.pid)) {
+    if (await matchesRuntime()) {
+      try { process.kill(runtime.pid, "SIGTERM"); } catch {}
+      for (let attempt = 0; attempt < 10 && processAlive(runtime.pid); attempt += 1) {
+        await new Promise(resolve => setTimeout(resolve, 100));
+      }
+    }
+  }
+  return !processAlive(runtime.pid);
+}
+
+function stopPeerMacService(peerHome: string) {
+  if (process.platform !== "darwin") return false;
+  const uid = process.getuid?.();
+  if (uid === undefined) return false;
+  const path = join(homedir(), "Library", "LaunchAgents", "com.better-codex.runtime.plist");
+  if (!existsSync(path)) return false;
+  const expectedHome = peerHome.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/\"/g, "&quot;");
+  try {
+    const plist = readFileSync(path, "utf8");
+    if (!plist.includes(`<key>BETTER_CODEX_HOME</key><string>${expectedHome}</string>`)) return false;
+  } catch {
+    return false;
+  }
+  const domain = `gui/${uid}`;
+  try {
+    execFileSync("/bin/launchctl", ["bootout", domain, path], { stdio: "ignore" });
+    return true;
+  } catch {
+    try {
+      execFileSync("/bin/launchctl", ["print", `${domain}/com.better-codex.runtime`], { stdio: "ignore" });
+    } catch {
+      return true;
+    }
+    throw new Error("peer_service_stop_failed");
+  }
+}
+
+async function deactivatePeerInstance() {
+  const peerHome = resolve(peerBetterCodexHome);
+  if (peerHome === resolve(betterCodexHome)) return null;
+  const peerRunPath = join(peerHome, "run");
+  const peerProfile = betterCodexProfile === "development" ? "stable" : "development";
+  const peerOwnership = injectionOwnership(peerProfile, peerRunPath, true);
+  const runtime = peerRuntimeState(peerRunPath);
+  const injector = peerInjectorPid(peerRunPath);
+  const serviceStopped = stopPeerMacService(peerHome);
+  const peerInjectionState = readJsonFile<{ enabled?: boolean }>(join(peerRunPath, "injection.json"));
+  const peerEnabled = peerInjectionState?.enabled !== false && peerInjectionState !== null;
+  const peerWasActive = Boolean(runtime || injector || serviceStopped || peerEnabled);
+  if (peerWasActive) await disablePeerInjection(peerRunPath);
+  const injectorStopped = await stopPeerInjector(peerRunPath);
+  if (injector && !injectorStopped) throw new Error("peer_injector_stop_failed");
+  const runtimeStopped = await stopPeerRuntime(peerHome, runtime);
+  if (runtime && !runtimeStopped) throw new Error("peer_runtime_stop_failed");
+  let injectionRemoved = false;
+  try {
+    const peerToken = existsSync(join(peerRunPath, "token")) ? readFileSync(join(peerRunPath, "token"), "utf8").trim() : "";
+    const result = await cdpEject(cdpPort, peerToken, peerOwnership);
+    injectionRemoved = result.some(item => item.uninstalled === true);
+  } catch {}
+  if (injectionRemoved && !peerWasActive) await disablePeerInjection(peerRunPath);
+  if (peerRuntimeState(peerRunPath) || peerInjectorPid(peerRunPath)) throw new Error("peer_instance_still_running");
+  if (!peerWasActive && !injectionRemoved) return null;
+  return {
+    profile: peerProfile,
+    serviceStopped,
+    injectorStopped,
+    runtimeStopped,
+    injectionRemoved,
+  };
 }
 
 function print(value: unknown) {
@@ -364,7 +625,7 @@ function print(value: unknown) {
 }
 
 function usage() {
-  console.log("better-codex version | update [check|compatibility|rollback] [--channel stable|preview] | setup [--yes] | launch | launcher install|uninstall|status | mcp install|uninstall|status | doctor | enable | disable | start [--launch] | stop | status | uninstall | data delete [--yes] | inject [--launch] [--port N] | eject [--port N] | service install|uninstall|start|stop|restart|status|logs | project list|create | agent list | issue list|get|create|update|status|open");
+  console.log("better-codex version | update [check|compatibility|rollback] [--channel stable|preview] | setup [--yes] | launch [--restart] | launcher install|uninstall|status | mcp install|uninstall|status | doctor | enable | disable | start [--launch] | stop | status | uninstall | data delete [--yes] | inject [--launch] [--port N] | eject [--port N] | service install|uninstall|start|stop|restart|status|logs | project list|create | agent list | issue list|get|create|update|status|open");
 }
 
 function selfCommand() {
@@ -492,7 +753,7 @@ async function doctor() {
   const mcp = mcpStatus();
   const updateKey = !isSea() || existsSync(updatePublicKeyPath);
   const checks = {
-    core: { ok: true, ...activeVersions(), executable: process.env.BETTER_CODEX_LAUNCHER_PATH ?? process.execPath },
+    core: { ok: true, ...activeVersions(), profile: betterCodexProfile, home: betterCodexHome, executable: process.env.BETTER_CODEX_LAUNCHER_PATH ?? process.execPath },
     service: { ok: service.installed, ...service },
     runtime,
     database,
@@ -512,7 +773,7 @@ async function uninstall() {
   setInjectionEnabled(false);
   await stopInjector();
   let injection: unknown = { removed: false, reason: "cdp_unavailable" };
-  try { injection = await cdpEject(cdpPort, accessToken()); } catch {}
+  try { injection = await cdpEject(cdpPort, accessToken(), injectionOwnership()); } catch {}
   try { await request("/api/shutdown", { method: "POST" }); } catch {}
   const launchIntegration = uninstallLaunchIntegration();
   const mcp = uninstallMcp();
@@ -627,7 +888,7 @@ async function main() {
   }
   if (command === "version" || command === "--version" || command === "-v") {
     const versions = activeVersions();
-    if ([action, ...args].includes("--json")) return console.log(JSON.stringify(versions));
+    if ([action, ...args].includes("--json")) return console.log(JSON.stringify({ ...versions, profile: betterCodexProfile, home: betterCodexHome }));
     return console.log(`better-codex core ${versions.core} compatibility ${versions.compatibility}`);
   }
   if (command === "update") {
@@ -674,7 +935,13 @@ async function main() {
     return usage();
   }
   if (command === "launch") {
+    const intent = await recordLaunchIntent([action, ...args].includes("--restart"));
     return print(await withLaunchLock(async () => {
+      const latestIntent = latestLaunchIntent();
+      if (latestIntent?.token !== intent.token) return { launched: false, superseded: true, requestedProfile: intent.profile };
+      markLaunchIntentProcessed(intent.sequence);
+      const restartRequested = latestIntent.restart === true;
+      const switchedFrom = await deactivatePeerInstance();
       const current = await cdpStatus(cdpPort);
       const codexRunning = codexProcessRunning() || current.available || current.targets.length > 0;
       if (!codexRunning) {
@@ -682,9 +949,22 @@ async function main() {
         await ensureRuntime();
         const injection = await cdpInject(cdpPort, activeRuntimePort(), accessToken(), true);
         startInjector(cdpPort);
-        return { launched: true, restarted: false, codexStarted: true, injection };
+        return { launched: true, restarted: false, codexStarted: true, switchedFrom, injection };
       }
-      if (!confirmLaunchRestart()) {
+      if (switchedFrom) {
+        setInjectionEnabled(true);
+        await ensureRuntime();
+        launchCodex(cdpPort, true);
+        try {
+          const injection = await cdpInject(cdpPort, activeRuntimePort(), accessToken(), true);
+          startInjector(cdpPort);
+          return { launched: true, restarted: false, openedCurrentCodex: true, switchedFrom, injection };
+        } catch (error) {
+          setInjectionEnabled(false);
+          throw error;
+        }
+      }
+      if (!restartRequested) {
         setInjectionEnabled(true);
         await ensureRuntime();
         launchCodex(cdpPort, true);
@@ -767,7 +1047,7 @@ async function main() {
     await stopInjector();
     const selectedPort = Number(option([action, ...args].filter(Boolean) as string[], "--port") ?? cdpPort);
     let injection: unknown = { available: false, disabled: true };
-    try { injection = await cdpEject(selectedPort, accessToken()); } catch {}
+    try { injection = await cdpEject(selectedPort, accessToken(), injectionOwnership()); } catch {}
     return print({ enabled: false, injection });
   }
   if (command === "uninstall") return print(await uninstall());
@@ -807,7 +1087,7 @@ async function main() {
   }
   if (command === "stop") {
     await stopInjector();
-    try { await cdpEject(cdpPort, accessToken()); } catch {}
+    try { await cdpEject(cdpPort, accessToken(), injectionOwnership()); } catch {}
     let runtime: unknown = { stopped: true, alreadyStopped: true };
     try { runtime = await request("/api/shutdown", { method: "POST" }); } catch {}
     return print({ runtime, injection: { stopped: true } });
@@ -815,7 +1095,30 @@ async function main() {
   if (command === "status") {
     let runtime: unknown;
     try { runtime = await health(); } catch (error) { runtime = { ok: false, error: error instanceof Error ? error.message : "runtime_unavailable" }; }
-    return print({ runtime, injection: await cdpStatus(Number(option([action, ...args].filter(Boolean) as string[], "--port") ?? cdpPort)), injectionEnabled: injectionEnabled(), injectorPid: injectorPid() });
+    return print({ profile: betterCodexProfile, home: betterCodexHome, runtime, injection: await cdpStatus(Number(option([action, ...args].filter(Boolean) as string[], "--port") ?? cdpPort)), injectionEnabled: injectionEnabled(), injectorPid: injectorPid() });
+  }
+  if (command === "refresh-injection") {
+    return print(await withLaunchLock(async () => {
+      const selectedPort = Number(option([action, ...args].filter(Boolean) as string[], "--port") ?? cdpPort);
+      const runtimeBeforeRefresh = readRuntimeState();
+      setInjectionEnabled(false);
+      await stopInjector();
+      try {
+        await ensureRuntime();
+        const removed = await cdpEject(selectedPort, accessToken(), injectionOwnership());
+        const injection = await cdpInject(selectedPort, activeRuntimePort(), accessToken(), false);
+        setInjectionEnabled(true);
+        const injectorPid = await waitForInjector();
+        return { refreshed: true, removed, injection, injectorPid };
+      } catch (error) {
+        setInjectionEnabled(false);
+        await stopInjector();
+        if (!runtimeBeforeRefresh && readRuntimeState()) {
+          try { await request("/api/shutdown", { method: "POST" }); } catch {}
+        }
+        throw error;
+      }
+    }));
   }
   if (command === "inject") {
     setInjectionEnabled(false);
@@ -838,7 +1141,7 @@ async function main() {
     setInjectionEnabled(false);
     const selectedPort = Number(option([action, ...args].filter(Boolean) as string[], "--port") ?? cdpPort);
     await stopInjector();
-    return print(await cdpEject(selectedPort, accessToken()));
+    return print(await cdpEject(selectedPort, accessToken(), injectionOwnership()));
   }
   await ensureRuntime();
   if (command === "project" && action === "list") return print(await request("/api/projects"));
@@ -855,14 +1158,9 @@ async function main() {
   usage();
 }
 
-const persistentCommand = ["runtime", "serve", "watch-inject"].includes(commandArguments()[0]);
-
-void main().then(() => {
-  if (!persistentCommand) setImmediate(() => process.exit(0));
-}).catch(error => {
+void main().catch(error => {
   console.error(error instanceof Error ? error.message : error);
-  if (!persistentCommand) setImmediate(() => process.exit(1));
-  else process.exitCode = 1;
+  process.exitCode = 1;
 });
 
 process.once("exit", () => {

--- a/src/compatibility.ts
+++ b/src/compatibility.ts
@@ -2,7 +2,7 @@ import { existsSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { compatibilityCurrentPath, compatibilityStatusPath, compatibilityVersionsPath, ensureDirectories, runtimeCurrentPath } from "./config.js";
 
-export const coreVersion = "0.3.17";
+export const coreVersion = "0.4.0";
 
 export type CompatibilityManifest = {
   version: string;

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,8 +4,19 @@ import { homedir } from "node:os";
 import { isSea } from "node:sea";
 import { join, resolve } from "node:path";
 
-const defaultHome = join(homedir(), ".better-codex");
+export type BetterCodexProfile = "stable" | "development";
+
+function configuredProfile(): BetterCodexProfile {
+  const value = process.env.BETTER_CODEX_PROFILE || "stable";
+  if (value === "stable" || value === "development") return value;
+  throw new Error("invalid_better_codex_profile");
+}
+
+export const betterCodexProfile = configuredProfile();
+const defaultHome = join(homedir(), betterCodexProfile === "development" ? ".better-codex-dev" : ".better-codex");
+const defaultPeerHome = join(homedir(), betterCodexProfile === "development" ? ".better-codex" : ".better-codex-dev");
 export const betterCodexHome = resolve(process.env.BETTER_CODEX_HOME || defaultHome);
+export const peerBetterCodexHome = resolve(process.env.BETTER_CODEX_PEER_HOME || defaultPeerHome);
 export const databasePath = resolve(process.env.BETTER_CODEX_DB || join(betterCodexHome, "better-codex.db"));
 export const runPath = join(betterCodexHome, "run");
 export const logPath = join(betterCodexHome, "logs");
@@ -35,7 +46,8 @@ export const injectionStatePath = join(runPath, "injection.json");
 export const mockupSessionPath = join(runPath, "mockup-session.json");
 export const mockupStatePath = join(betterCodexHome, "mockup.json");
 export const launchIntegrationStatePath = join(runPath, "launch-integration.json");
-export const launchLockPath = join(runPath, "launch.lock");
+export const launchLockPath = join(homedir(), ".better-codex-launch.lock");
+export const launchIntentPath = join(homedir(), ".better-codex-launch-intents");
 export const runtimePort = Number(process.env.BETTER_CODEX_RUNTIME_PORT ?? process.env.BETTER_CODEX_PORT ?? 0);
 export const cdpPort = Number(process.env.BETTER_CODEX_CDP_PORT ?? 9229);
 export const debugLoggingEnabled = !isSea();

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -1,5 +1,6 @@
 import { activeCompatibility, coreVersion } from "./compatibility.js";
 import { betterCodexLogoPng } from "./brand-assets.js";
+import { betterCodexProfile } from "./config.js";
 import { betterCodexDesignSystemCss } from "./design-system.js";
 import { renderMarkdown } from "./markdown.js";
 import { betterCodexMcpRoute } from "./mcp-app.js";
@@ -263,9 +264,10 @@ export function injectionScript(port: number, accessToken: string, action: "inst
     "use strict";
     const VERSION = ${JSON.stringify(compatibility.version)};
     const CORE_VERSION = ${JSON.stringify(coreVersion)};
+    const PROFILE = ${JSON.stringify(betterCodexProfile)};
     const HELP_MODE_MARKDOWN = ${helpModeMarkdown};
     const previous = window.__betterCodexInjection__;
-    if (previous?.version === VERSION && previous?.endpoint === ${baseUrl}) {
+    if (previous?.version === VERSION && previous?.endpoint === ${baseUrl} && previous?.profile === PROFILE) {
       previous.refresh();
       return { installed: true, reused: true };
     }
@@ -473,6 +475,9 @@ export function injectionScript(port: number, accessToken: string, action: "inst
       "已经执行过对话的 Issue 只能修改状态、优先级和指派人。": "Issues with an executed conversation can only change status, priority, and assignee.", "终止任务后才能打开对话，是否终止任务？": "The task must be stopped before opening the conversation. Stop it now?", "终止并打开": "Stop and open", "正在终止…": "Stopping…", "忽略当前版本": "Ignore this version", "立即更新": "Update now", "暂无项目": "No projects", "告诉智能体要做什么，例如：“修复项目里任务运行状态不可见的问题”": "Tell the agent what to do, for example: “Fix the invisible task run status in the project”"
     } };
     localeResources.en["手动创建 issue"] = "Create issue manually";
+    localeResources.en["源码开发版"] = "Source development build";
+    localeResources.en["发现兼容更新"] = "Compatibility update available";
+    localeResources.en["源码开发版仅检查兼容层更新，核心版本请更新源码并重新构建。"] = "Source builds only check for compatibility updates. Update the source and rebuild to change the core version.";
     localeResources.en["有任务正在运行，请等待任务结束后再更新。"] = "A task is running. Wait for it to finish before updating.";
     localeResources.en["更新正在进行中，请稍候。"] = "An update is already in progress. Please wait.";
     localeResources.en["下载的更新版本与发布版本不一致，请稍后重试。"] = "The downloaded version does not match the release. Try again later.";
@@ -3077,7 +3082,9 @@ export function injectionScript(port: number, accessToken: string, action: "inst
       });
       const checkUpdate = dialog.querySelector("[data-check-update]");
       const renderUpdateState = (update, checked = false) => {
-        checkUpdate.textContent = t(update?.status === "available" ? "发现新版本" : update?.status === "error" ? "无法检查更新" : checked ? "已是最新版本" : "检查新版本");
+        const sourceBuild = update?.coreUpdateSupported === false;
+        checkUpdate.textContent = t(update?.status === "available" ? (sourceBuild ? "发现兼容更新" : "发现新版本") : update?.status === "error" ? "无法检查更新" : sourceBuild ? "源码开发版" : checked ? "已是最新版本" : "检查新版本");
+        checkUpdate.title = sourceBuild ? t("源码开发版仅检查兼容层更新，核心版本请更新源码并重新构建。") : "";
       };
       checkUpdate.addEventListener("click", async () => {
         checkUpdate.disabled = true;
@@ -4866,7 +4873,7 @@ export function injectionScript(port: number, accessToken: string, action: "inst
       updateTimer = setInterval(checkUpdateNotice, 15000);
     }
 
-    window.__betterCodexInjection__ = { version: VERSION, endpoint: BASE_URL, refresh, open: openRoute, close, destroy };
+    window.__betterCodexInjection__ = { version: VERSION, profile: PROFILE, endpoint: BASE_URL, refresh, open: openRoute, close, destroy };
     document.addEventListener("click", onClick, true);
     document.addEventListener("keydown", onGlobalShortcut, true);
     window.addEventListener("codex-message-from-view", onHostMessageFromView, true);

--- a/src/injection-state.ts
+++ b/src/injection-state.ts
@@ -1,6 +1,23 @@
 import { existsSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
 import { ensureDirectories, injectionStatePath, mockupSessionPath } from "./config.js";
 
+type InjectionState = { enabled?: boolean; profile?: string; endpoint?: string };
+
+function readInjectionState(): InjectionState {
+  try {
+    return JSON.parse(readFileSync(injectionStatePath, "utf8")) as InjectionState;
+  } catch {
+    return {};
+  }
+}
+
+function writeInjectionState(state: InjectionState) {
+  ensureDirectories();
+  const temporary = `${injectionStatePath}.${process.pid}.tmp`;
+  writeFileSync(temporary, JSON.stringify(state), { mode: 0o600 });
+  renameSync(temporary, injectionStatePath);
+}
+
 export function mockupSessionActive() {
   if (!existsSync(mockupSessionPath)) return false;
   try {
@@ -19,17 +36,14 @@ export function mockupSessionActive() {
 
 export function injectionEnabled() {
   mockupSessionActive();
-  try {
-    return JSON.parse(readFileSync(injectionStatePath, "utf8")).enabled !== false;
-  } catch {
-    return true;
-  }
+  return readInjectionState().enabled !== false;
 }
 
 export function setInjectionEnabled(enabled: boolean) {
-  ensureDirectories();
-  const temporary = `${injectionStatePath}.${process.pid}.tmp`;
-  writeFileSync(temporary, JSON.stringify({ enabled }), { mode: 0o600 });
-  renameSync(temporary, injectionStatePath);
+  writeInjectionState({ ...readInjectionState(), enabled });
   return enabled;
+}
+
+export function recordInjectionOwnership(profile: string, endpoint: string) {
+  writeInjectionState({ ...readInjectionState(), profile, endpoint });
 }

--- a/src/launch-integration.ts
+++ b/src/launch-integration.ts
@@ -5,7 +5,7 @@ import { basename, dirname, join, resolve } from "node:path";
 import { homedir } from "node:os";
 import { isSea } from "node:sea";
 import { appIconIcns, appIconIco } from "./brand-assets.js";
-import { betterCodexHome, ensureDirectories, launchIntegrationStatePath, logPath } from "./config.js";
+import { betterCodexHome, betterCodexProfile, ensureDirectories, launchIntegrationStatePath, logPath, peerBetterCodexHome } from "./config.js";
 
 type WindowsOwnedShortcut = {
   path: string;
@@ -30,15 +30,19 @@ type LaunchIntegrationState = {
   shortcuts?: Array<WindowsOwnedShortcut | WindowsLegacyShortcut>;
 };
 
-const MAC_BUNDLE_ID = "com.better-codex.launcher";
+const developmentProfile = betterCodexProfile === "development";
+const launcherDisplayName = developmentProfile ? "Better Codex Dev" : "Better Codex";
+const MAC_BUNDLE_ID = developmentProfile ? "com.better-codex.launcher.dev" : "com.better-codex.launcher";
 const MAC_OWNERSHIP_FILE = ".better-codex-owner";
-const WINDOWS_SHORTCUT_NAME = "Better Codex.lnk";
+const WINDOWS_SHORTCUT_NAME = `${launcherDisplayName}.lnk`;
+const WINDOWS_LAUNCHER_SCRIPT_NAME = `${launcherDisplayName} Launcher.vbs`;
 
 function macLauncherPath() {
-  return "/Applications/Better Codex.app";
+  return `/Applications/${launcherDisplayName}.app`;
 }
 
 function legacyMacLauncherPaths() {
+  if (developmentProfile) return [];
   return [
     "/Applications/Better Codex Launcher.app",
     join(homedir(), "Applications", "Better Codex Launcher.app"),
@@ -171,11 +175,14 @@ function launcherCommand() {
   if (process.platform !== "win32") return command;
 
   ensureDirectories();
-  const scriptPath = join(betterCodexHome, "Better Codex Launcher.vbs");
+  const scriptPath = join(betterCodexHome, WINDOWS_LAUNCHER_SCRIPT_NAME);
   const commandLine = command.map(value => `"${value.replace(/"/g, "\"\"")}"`).join(" ");
   writeFileSync(scriptPath, `Option Explicit
 Dim shell
 Set shell = CreateObject("WScript.Shell")
+shell.Environment("Process")("BETTER_CODEX_PROFILE") = "${betterCodexProfile}"
+shell.Environment("Process")("BETTER_CODEX_HOME") = "${betterCodexHome.replace(/"/g, "\"\"")}"
+shell.Environment("Process")("BETTER_CODEX_PEER_HOME") = "${peerBetterCodexHome.replace(/"/g, "\"\"")}"
 shell.Run "${commandLine.replace(/"/g, '""')}" & " launch", 0, False
 `, { mode: 0o600 });
   return [join(process.env.SystemRoot ?? "C:\\Windows", "System32", "wscript.exe"), scriptPath];
@@ -221,9 +228,20 @@ function writeWindowsAppIcon() {
 
 function macLauncherScript(command: string[]) {
   return `#!/bin/sh
+BETTER_CODEX_PROFILE=${shellSingleQuoted(betterCodexProfile)} BETTER_CODEX_HOME=${shellSingleQuoted(betterCodexHome)} BETTER_CODEX_PEER_HOME=${shellSingleQuoted(peerBetterCodexHome)} ${command.map(shellSingleQuoted).join(" ")} launch >>${shellSingleQuoted(join(logPath, "launcher.log"))} 2>&1 &
+exit 0
+`;
+}
+
+function legacyMacLauncherScript(command: string[]) {
+  return `#!/bin/sh
 ${command.map(shellSingleQuoted).join(" ")} launch >>${shellSingleQuoted(join(logPath, "launcher.log"))} 2>&1 &
 exit 0
 `;
+}
+
+export function macLauncherOwnershipScripts(command: string[]) {
+  return developmentProfile ? [macLauncherScript(command)] : [macLauncherScript(command), legacyMacLauncherScript(command)];
 }
 
 function assertOwnedMacApp(appPath: string, state: LaunchIntegrationState | null) {
@@ -237,7 +255,10 @@ function assertOwnedMacApp(appPath: string, state: LaunchIntegrationState | null
   const marker = join(contents, "Resources", MAC_OWNERSHIP_FILE);
   if (state.ownershipToken && existsSync(marker) && !lstatSync(marker).isSymbolicLink() && readFileSync(marker, "utf8") === state.ownershipToken) return;
   const executable = join(contents, "MacOS", "better-codex-launcher");
-  if (!state.ownershipToken && existsSync(executable) && !lstatSync(executable).isSymbolicLink() && readFileSync(executable, "utf8") === macLauncherScript([state.launcher, ...(state.launcherArguments ?? [])])) return;
+  if (!state.ownershipToken && existsSync(executable) && !lstatSync(executable).isSymbolicLink()) {
+    const scriptContents = readFileSync(executable, "utf8");
+    if (macLauncherOwnershipScripts([state.launcher, ...(state.launcherArguments ?? [])]).includes(scriptContents)) return;
+  }
   throw new Error("mac_launcher_path_occupied");
 }
 
@@ -258,14 +279,11 @@ function installMacLauncher(command: string[], previous: LaunchIntegrationState 
   const ownedState = migrated && previous ? { ...previous, appPath } : previous;
   if (existsSync(appPath)) assertOwnedMacApp(appPath, ownedState);
   const existingContents = join(appPath, "Contents");
-  const stableCommand = existsSync(appPath) && previous?.platform === "darwin" && resolve(previous.launcher) === resolve(command[0])
+  const stableCommand = betterCodexProfile === "stable" && existsSync(appPath) && previous?.platform === "darwin" && resolve(previous.launcher) === resolve(command[0])
     ? [previous.launcher, ...(previous.launcherArguments ?? [])]
     : command;
   const [launcher, ...launcherArguments] = stableCommand;
-  const expectedScript = `#!/bin/sh
-${stableCommand.map(shellSingleQuoted).join(" ")} launch >>${shellSingleQuoted(join(logPath, "launcher.log"))} 2>&1 &
-exit 0
-`;
+  const expectedScript = macLauncherScript(stableCommand);
   const ownershipToken = ownedState?.ownershipToken ?? randomUUID();
   if (existsSync(appPath)) {
     const existingExecutable = join(existingContents, "MacOS", "better-codex-launcher");
@@ -295,11 +313,11 @@ exit 0
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0"><dict>
 <key>CFBundleDevelopmentRegion</key><string>en</string>
-<key>CFBundleDisplayName</key><string>Better Codex</string>
+<key>CFBundleDisplayName</key><string>${launcherDisplayName}</string>
 <key>CFBundleExecutable</key><string>better-codex-launcher</string>
 <key>CFBundleIconFile</key><string>AppIcon</string>
 <key>CFBundleIdentifier</key><string>${MAC_BUNDLE_ID}</string>
-<key>CFBundleName</key><string>Better Codex</string>
+<key>CFBundleName</key><string>${launcherDisplayName}</string>
 <key>CFBundlePackageType</key><string>APPL</string>
 <key>CFBundleShortVersionString</key><string>1.0</string>
 </dict></plist>
@@ -331,7 +349,8 @@ $launcher = ${powershellLiteral(state.launcher)}
 $launchArguments = ${powershellLiteral(expectedArguments)}
 $backupDirectory = ${powershellLiteral(backupDirectory)}
 $json = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String(${powershellLiteral(payload)}))
-$items = @($json | ConvertFrom-Json)
+$items = @(ConvertFrom-Json -InputObject $json)
+if ($items.Count -eq 1 -and $items[0] -is [Array]) { $items = @($items[0]) }
 $roots = @(
   [Environment]::GetFolderPath('Desktop'),
   [Environment]::GetFolderPath('StartMenu'),
@@ -419,7 +438,7 @@ foreach ($path in $paths) {
   $shortcut.TargetPath = $launcher
   $shortcut.Arguments = $launchArguments
   $shortcut.WorkingDirectory = [IO.Path]::GetDirectoryName($launcher)
-  $shortcut.Description = 'Better Codex'
+$shortcut.Description = ${powershellLiteral(launcherDisplayName)}
   $shortcut.IconLocation = $iconLocation
   $shortcut.Save()
   $created += [pscustomobject]@{ path = $path }
@@ -446,7 +465,8 @@ function removeOwnedWindowsShortcuts(state: LaunchIntegrationState) {
 $launcher = ${powershellLiteral(state.launcher)}
 $launchArguments = ${powershellLiteral(expectedArguments)}
 $json = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String(${powershellLiteral(payload)}))
-$items = @($json | ConvertFrom-Json)
+$items = @(ConvertFrom-Json -InputObject $json)
+if ($items.Count -eq 1 -and $items[0] -is [Array]) { $items = @($items[0]) }
 $roots = @(
   [Environment]::GetFolderPath('Desktop'),
   (Join-Path ([Environment]::GetFolderPath('StartMenu')) 'Programs')
@@ -494,7 +514,8 @@ function windowsShortcutStatus(state: LaunchIntegrationState) {
 $launcher = ${powershellLiteral(state.launcher)}
 $launchArguments = ${powershellLiteral(expectedArguments)}
 $json = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String(${powershellLiteral(payload)}))
-$items = @($json | ConvertFrom-Json)
+$items = @(ConvertFrom-Json -InputObject $json)
+if ($items.Count -eq 1 -and $items[0] -is [Array]) { $items = @($items[0]) }
 $shell = New-Object -ComObject WScript.Shell
 $healthy = 0
 $drifted = 0

--- a/src/runtime-state.ts
+++ b/src/runtime-state.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
-import { closeSync, existsSync, openSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { closeSync, existsSync, openSync, readFileSync, renameSync, statSync, unlinkSync, writeFileSync } from "node:fs";
 import { ensureDirectories, runtimeLockPath, runtimeStatePath } from "./config.js";
 import { coreVersion } from "./compatibility.js";
 
@@ -9,6 +10,7 @@ export type RuntimeState = {
   instanceId: string;
   version: string;
   startedAt: string;
+  processStartedAt: string;
 };
 
 function processAlive(pid: number) {
@@ -17,6 +19,18 @@ function processAlive(pid: number) {
     return true;
   } catch {
     return false;
+  }
+}
+
+function processStartTime(pid: number) {
+  try {
+    const value = process.platform === "win32"
+      ? execFileSync("powershell.exe", ["-NoProfile", "-NonInteractive", "-Command", `$process = Get-CimInstance Win32_Process -Filter \"ProcessId = ${pid}\"; if ($process) { $process.CreationDate.ToUniversalTime().ToString('o') }`], { encoding: "utf8", windowsHide: true }).trim()
+      : execFileSync("ps", ["-p", String(pid), "-o", "lstart="], { encoding: "utf8" }).trim();
+    const parsed = Date.parse(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  } catch {
+    return null;
   }
 }
 
@@ -41,20 +55,28 @@ export function createRuntimeIdentity() {
     instanceId: randomUUID(),
     version: coreVersion,
     startedAt: new Date().toISOString(),
+    processStartedAt: new Date(processStartTime(process.pid) ?? Date.now()).toISOString(),
   };
 }
 
-export function acquireRuntimeLock(instanceId: string) {
+export function acquireRuntimeLock(identity: Pick<RuntimeState, "instanceId" | "startedAt" | "processStartedAt">) {
   ensureDirectories();
   for (let attempt = 0; attempt < 2; attempt += 1) {
     try {
       const descriptor = openSync(runtimeLockPath, "wx", 0o600);
-      writeFileSync(descriptor, JSON.stringify({ pid: process.pid, instanceId }));
+      writeFileSync(descriptor, JSON.stringify({ pid: process.pid, instanceId: identity.instanceId, startedAt: identity.startedAt, processStartedAt: identity.processStartedAt }));
       closeSync(descriptor);
       return;
     } catch (error) {
       const current = parse(runtimeLockPath);
-      if (current?.pid && processAlive(current.pid)) throw new Error("runtime_already_running");
+      if (current?.pid && processAlive(current.pid)) {
+        const expectedStart = typeof current.processStartedAt === "string" ? Date.parse(current.processStartedAt) : NaN;
+        const observedStart = processStartTime(current.pid);
+        const reused = Number.isFinite(expectedStart) && observedStart !== null && Math.abs(expectedStart - observedStart) > 1500;
+        let legacyStale = false;
+        try { legacyStale = !current.processStartedAt && Date.now() - statSync(runtimeLockPath).mtimeMs > 30_000; } catch {}
+        if (!reused && !legacyStale) throw new Error("runtime_already_running");
+      }
       if (existsSync(runtimeLockPath)) unlinkSync(runtimeLockPath);
       if (attempt === 1) throw error;
     }

--- a/src/server.ts
+++ b/src/server.ts
@@ -304,7 +304,7 @@ function spawnUpdateRelaunch(runtimePid: number, updates: { core: string | null;
 export function startServer() {
   if (!Number.isInteger(runtimePort) || runtimePort < 0 || runtimePort > 65535) throw new Error("invalid_runtime_port");
   const identity = createRuntimeIdentity();
-  acquireRuntimeLock(identity.instanceId);
+  acquireRuntimeLock(identity);
   let store: Store;
   try {
     store = new Store();

--- a/src/service.ts
+++ b/src/service.ts
@@ -3,7 +3,7 @@ import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "
 import { homedir } from "node:os";
 import { isAbsolute, join, relative, resolve } from "node:path";
 import { isSea } from "node:sea";
-import { cdpPort, ensureDirectories, logPath, runtimeLogPath, betterCodexHome, runPath } from "./config.js";
+import { betterCodexHome, betterCodexProfile, cdpPort, ensureDirectories, logPath, runPath, runtimeLogPath } from "./config.js";
 
 const label = "com.better-codex.runtime";
 const legacyLabel = "com.better-codex.gateway";
@@ -99,6 +99,7 @@ function domain() {
 }
 
 export function installService() {
+  if (betterCodexProfile === "development") return { installed: false, label: "Better Codex Dev Runtime", path: null, reason: "development_runtime_unmanaged" };
   ensureDirectories();
   if (process.platform === "win32") {
     reg(["ADD", windowsRunKey, "/V", windowsTask, "/T", "REG_SZ", "/D", windowsStartupCommand(), "/F"]);
@@ -117,6 +118,7 @@ export function installService() {
 }
 
 export function uninstallService() {
+  if (betterCodexProfile === "development") return { installed: false, label: "Better Codex Dev Runtime", path: null, reason: "development_runtime_unmanaged" };
   if (process.platform === "win32") {
     stopService();
     reg(["DELETE", windowsRunKey, "/V", windowsTask, "/F"], true);
@@ -131,6 +133,7 @@ export function uninstallService() {
 }
 
 export function startService() {
+  if (betterCodexProfile === "development") throw new Error("development_runtime_unmanaged");
   if (process.platform === "win32") {
     if (!serviceStatus().installed) throw new Error("service_not_installed");
     if (!windowsRuntime()) {
@@ -147,6 +150,7 @@ export function startService() {
 }
 
 export function stopService() {
+  if (betterCodexProfile === "development") return { stopped: true, label: "Better Codex Dev Runtime", unmanaged: true };
   if (process.platform === "win32") {
     const pid = windowsRuntime();
     if (pid) {
@@ -164,6 +168,7 @@ export function restartService() {
 }
 
 export function serviceStatus() {
+  if (betterCodexProfile === "development") return { installed: false, running: false, pid: null, label: "Better Codex Dev Runtime", path: null, reason: "development_runtime_unmanaged" };
   if (process.platform === "win32") {
     const output = reg(["QUERY", windowsRunKey, "/V", windowsTask], true);
     const installed = Boolean(output);

--- a/src/updater.ts
+++ b/src/updater.ts
@@ -43,6 +43,7 @@ export type GatewayUpdateState = {
   latestVersion: string | null;
   checkedAt: string | null;
   error: string | null;
+  coreUpdateSupported?: boolean;
 };
 
 type ActivationState = {
@@ -236,7 +237,7 @@ export function getGatewayUpdateState() {
     const persisted = persistedActivationState();
     if (persisted.status !== "restarting") gatewayUpdateState = persisted.status === "idle" ? { ...persisted, status: "current" } : persisted;
   }
-  return { ...gatewayUpdateState, currentVersion: effectiveCoreVersion() };
+  return { ...gatewayUpdateState, currentVersion: effectiveCoreVersion(), coreUpdateSupported: isSea() };
 }
 
 export function recordGatewayUpdateActivation(status: "activating" | "success" | "error", error: string | null = null, updates: { core: string | null; compatibility: string | null } = { core: null, compatibility: null }, ownerPid: number | null = null) {
@@ -257,11 +258,13 @@ export function checkGatewayUpdate() {
       gatewayUpdateState = { ...getGatewayUpdateState(), status: "error", checkedAt, error: "error" in result ? result.error : "update_check_failed" };
       return getGatewayUpdateState();
     }
-    const available = Boolean(result.core?.available || result.compatibility?.available);
-    const latestVersion = result.core?.available
-      ? result.core.version
-      : result.compatibility?.available
-        ? result.compatibility.version
+    const coreAvailable = Boolean(isSea() && result.core?.available);
+    const compatibilityAvailable = Boolean(result.compatibility?.available);
+    const available = coreAvailable || compatibilityAvailable;
+    const latestVersion = coreAvailable
+      ? result.core?.version ?? effectiveCoreVersion()
+      : compatibilityAvailable
+        ? result.compatibility?.version ?? effectiveCoreVersion()
         : effectiveCoreVersion();
     gatewayUpdateState = { status: available ? "available" : "current", currentVersion: effectiveCoreVersion(), latestVersion, checkedAt, error: null };
     return getGatewayUpdateState();

--- a/test/cdp-lifecycle.test.ts
+++ b/test/cdp-lifecycle.test.ts
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+import { createServer } from "node:http";
+import test from "node:test";
+
+test("a CDP WebSocket child process closes cleanly on supported Node versions", async () => {
+  const server = createServer();
+  server.on("upgrade", (request, socket) => {
+    const key = String(request.headers["sec-websocket-key"] ?? "");
+    const accept = createHash("sha1").update(`${key}258EAFA5-E914-47DA-95CA-C5AB0DC85B11`).digest("base64");
+    socket.write([
+      "HTTP/1.1 101 Switching Protocols",
+      "Upgrade: websocket",
+      "Connection: Upgrade",
+      `Sec-WebSocket-Accept: ${accept}`,
+      "",
+      "",
+    ].join("\r\n"));
+    socket.once("data", () => {
+      socket.write(Buffer.from([0x88, 0x00]));
+      socket.end();
+    });
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => resolve());
+  });
+  try {
+    const address = server.address();
+    assert.ok(address && typeof address === "object");
+    const script = "const { closeCdpConnectionForTest } = await import('./src/cdp.ts'); await closeCdpConnectionForTest(process.argv[1]); console.log('closed');";
+    const child = spawn(process.execPath, ["--import", "tsx", "--input-type=module", "-e", script, `ws://127.0.0.1:${address.port}`], {
+      cwd: new URL("..", import.meta.url),
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", chunk => { stdout += chunk; });
+    child.stderr.on("data", chunk => { stderr += chunk; });
+    const code = await new Promise<number | null>((resolve, reject) => {
+      child.once("error", reject);
+      child.once("close", resolve);
+    });
+    assert.equal(code, 0, stderr);
+    assert.match(stdout, /closed/);
+    assert.doesNotMatch(stderr, /Assertion failed|UV_HANDLE_CLOSING/);
+  } finally {
+    await new Promise<void>(resolve => server.close(() => resolve()));
+  }
+});

--- a/test/gateway.test.ts
+++ b/test/gateway.test.ts
@@ -35,7 +35,8 @@ function startGateway(home: string, port: number, token: string) {
 async function waitForGateway(port: number, process: ChildProcess) {
   let output = "";
   process.stderr?.on("data", chunk => { output += String(chunk); });
-  for (let attempt = 0; attempt < 80; attempt += 1) {
+  const deadline = Date.now() + 15_000;
+  while (Date.now() < deadline) {
     if (process.exitCode !== null) throw new Error(output || `gateway_exit_${process.exitCode}`);
     try {
       const response = await fetch(`http://127.0.0.1:${port}/health`);

--- a/test/install-script.test.ts
+++ b/test/install-script.test.ts
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const installerPath = new URL("../scripts/install.ps1", import.meta.url);
+const source = readFileSync(installerPath, "utf8");
+
+test("Windows installer captures native stderr without turning progress into a terminating error", {
+  skip: process.platform !== "win32" ? "requires Windows PowerShell 5.1" : false,
+}, () => {
+  const script = String.raw`
+$source = Get-Content -Raw -LiteralPath $env:BETTER_CODEX_INSTALLER_TEST_PATH
+$tokens = $null
+$parseErrors = $null
+$ast = [Management.Automation.Language.Parser]::ParseInput($source, [ref]$tokens, [ref]$parseErrors)
+if ($parseErrors.Count -gt 0) { throw ($parseErrors | Out-String) }
+$function = $ast.Find({
+  param($node)
+  $node -is [Management.Automation.Language.FunctionDefinitionAst] -and $node.Name -eq "Invoke-NativeCapture"
+}, $true)
+if (-not $function) { throw "Invoke-NativeCapture is missing" }
+Invoke-Expression $function.Extent.Text
+
+$ErrorActionPreference = "Stop"
+$success = Invoke-NativeCapture $env:ComSpec @("/d", "/c", "echo installing_runtime 1>&2 & exit /b 0")
+$failure = Invoke-NativeCapture $env:ComSpec @("/d", "/c", "echo actual_failure 1>&2 & exit /b 7")
+
+if ($success.ExitCode -ne 0) { throw "success exit code was $($success.ExitCode)" }
+if ($success.Output -notmatch "installing_runtime") { throw "success stderr was not captured" }
+if ($failure.ExitCode -ne 7) { throw "failure exit code was $($failure.ExitCode)" }
+if ($failure.Output -notmatch "actual_failure") { throw "failure stderr was not captured" }
+if ($ErrorActionPreference -ne "Stop") { throw "ErrorActionPreference was not restored" }
+`;
+
+  const result = spawnSync("powershell.exe", ["-NoProfile", "-NonInteractive", "-Command", script], {
+    encoding: "utf8",
+    env: { ...process.env, BETTER_CODEX_INSTALLER_TEST_PATH: installerPath.pathname.replace(/^\/(.:)/, "$1") },
+  });
+
+  assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+});
+
+test("all installer commands that merge native stderr use the compatibility wrapper", () => {
+  assert.match(source, /function Invoke-NativeCapture/);
+  assert.deepEqual(
+    source.split(/\r?\n/).filter((line) => line.includes("2>&1")).map((line) => line.trim()),
+    ["$output = (& $Executable @Arguments 2>&1 | Out-String)"],
+  );
+  assert.match(source, /Invoke-NativeCapture \$executable @\("setup", "--yes"\)/);
+});

--- a/test/launch-integration.test.ts
+++ b/test/launch-integration.test.ts
@@ -1,25 +1,34 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import test from "node:test";
+import { macLauncherOwnershipScripts } from "../src/launch-integration.js";
 
 const source = readFileSync(new URL("../src/launch-integration.ts", import.meta.url), "utf8");
 const cliSource = readFileSync(new URL("../src/cli.ts", import.meta.url), "utf8");
 
 test("macOS launcher is named Better Codex.app and delegates to launch", () => {
-  assert.match(source, /\/Applications\/Better Codex\.app/);
+  assert.match(source, /launcherDisplayName = developmentProfile \? "Better Codex Dev" : "Better Codex"/);
+  assert.match(source, /`\/Applications\/\$\{launcherDisplayName\}\.app`/);
   assert.match(source, /Better Codex Launcher\.app/);
-  assert.match(source, /stableCommand\.map\(shellSingleQuoted\)\.join\(" "\)\} launch/);
+  assert.match(source, /BETTER_CODEX_PROFILE=\$\{shellSingleQuoted\(betterCodexProfile\)\}/);
+  assert.match(source, /BETTER_CODEX_HOME=\$\{shellSingleQuoted\(betterCodexHome\)\}/);
+  assert.match(source, /BETTER_CODEX_PEER_HOME=\$\{shellSingleQuoted\(peerBetterCodexHome\)\}/);
   assert.match(source, /com\.better-codex\.launcher/);
-  assert.match(source, /CFBundleDisplayName<\/key><string>Better Codex<\/string>/);
+  assert.match(source, /CFBundleDisplayName<\/key><string>\$\{launcherDisplayName\}<\/string>/);
+  const ownershipScripts = macLauncherOwnershipScripts(["/tmp/better-codex"]);
+  assert.equal(ownershipScripts.length, 2);
+  assert.match(ownershipScripts[0], /BETTER_CODEX_PROFILE=/);
+  assert.doesNotMatch(ownershipScripts[1], /BETTER_CODEX_PROFILE=/);
 });
 
 test("Windows creates owned Better Codex shortcuts instead of rewriting Codex shortcuts", () => {
-  assert.match(source, /Better Codex\.lnk/);
+  assert.match(source, /WINDOWS_SHORTCUT_NAME = `\$\{launcherDisplayName\}\.lnk`/);
+  assert.match(source, /WINDOWS_LAUNCHER_SCRIPT_NAME = `\$\{launcherDisplayName\} Launcher\.vbs`/);
   assert.match(source, /Join-Path \$desktop/);
   assert.match(source, /Join-Path \$startMenu/);
   assert.match(source, /\$shortcut\.TargetPath = \$launcher/);
   assert.match(source, /\$shortcut\.Arguments = \$launchArguments/);
-  assert.match(source, /\$shortcut\.Description = 'Better Codex'/);
+  assert.match(source, /\$shortcut\.Description = \$\{powershellLiteral\(launcherDisplayName\)\}/);
   assert.match(source, /Remove-Item -LiteralPath \$path/);
   assert.match(source, /shortcut_restore_incomplete_/);
   assert.match(source, /shortcut_remove_incomplete_/);
@@ -32,7 +41,9 @@ test("Windows creates owned Better Codex shortcuts instead of rewriting Codex sh
   assert.match(source, /windowsLegacyShortcutRoots/);
   assert.match(source, /wscript\.exe/);
   assert.match(source, /shell\.Run/);
-  assert.match(source, /Better Codex Launcher\.vbs/);
+  assert.match(source, /BETTER_CODEX_PROFILE/);
+  assert.match(source, /BETTER_CODEX_HOME/);
+  assert.match(source, /BETTER_CODEX_PEER_HOME/);
 });
 
 test("macOS and Windows launchers use the Better Codex brand icon", () => {
@@ -51,6 +62,7 @@ test("launcher serializes concurrent Codex restarts and keeps migration guards",
   assert.match(cliSource, /return print\(await withLaunchLock/);
   assert.match(cliSource, /owner\.token === token/);
   assert.match(cliSource, /renameSync\(launchLockPath, stalePath\)/);
+  assert.match(cliSource, /const switchedFrom = await deactivatePeerInstance\(\)/);
   assert.match(source, /validateState/);
   assert.match(source, /macBundleIdentifier\(info\) === MAC_BUNDLE_ID/);
   assert.match(source, /temporaryApp/);
@@ -62,22 +74,23 @@ test("launcher serializes concurrent Codex restarts and keeps migration guards",
   assert.match(source, /Test-ManagedBackup/);
   assert.match(source, /mac_launcher_replacement_required/);
   assert.match(source, /previous\?\.platform === "darwin"/);
+  assert.match(source, /betterCodexProfile === "stable" && existsSync\(appPath\)/);
   assert.match(source, /migrateLegacyMacLauncher/);
 });
 
-test("shortcut launch offers a full restart or opens the current Codex", () => {
-  assert.match(cliSource, /function confirmLaunchRestart\(\)/);
-  assert.match(cliSource, /当前进程正在运行/);
+test("shortcut launch opens the current Codex and supports an explicit restart", () => {
   assert.match(cliSource, /openedCurrentCodex: true/);
   assert.match(cliSource, /async function restartRuntime\(\)/);
   assert.match(cliSource, /restarted: true/);
   assert.match(cliSource, /const codexRunning = codexProcessRunning\(\) \|\| current\.available \|\| current\.targets\.length > 0/);
   assert.match(cliSource, /codexStarted: true/);
   assert.match(cliSource, /await cdpRestartAndInject\(cdpPort, activeRuntimePort\(\), accessToken\(\), \{ confirmQuit: false \}\)/);
+  assert.match(cliSource, /includes\("--restart"\)/);
+  assert.match(cliSource, /latestIntent\.restart === true/);
 });
 
 test("shortcut launch restores the bridge when keeping the current Codex", () => {
-  const start = cliSource.indexOf("if (!confirmLaunchRestart()) {");
+  const start = cliSource.indexOf("if (!restartRequested) {");
   const end = cliSource.indexOf("return { launched: true, restarted: false, openedCurrentCodex: true, injection }", start);
   assert.ok(start >= 0 && end > start);
   const branch = cliSource.slice(start, end);
@@ -89,4 +102,15 @@ test("shortcut launch restores the bridge when keeping the current Codex", () =>
 test("injector pid validation checks the process command", () => {
   assert.match(cliSource, /function isInjectorProcess\(pid: number\)/);
   assert.match(cliSource, /processAlive\(pid\) && isInjectorProcess\(pid\)/);
+});
+
+test("launcher coalesces clicks to the latest profile intent and leases the shared lock", () => {
+  assert.match(cliSource, /recordLaunchIntent/);
+  assert.match(cliSource, /latestIntent\?\.token !== intent\.token/);
+  assert.match(cliSource, /superseded: true/);
+  assert.match(cliSource, /nextLaunchIntentSequence/);
+  assert.match(cliSource, /markLaunchIntentProcessed/);
+  assert.match(cliSource, /utimesSync\(launchLockPath/);
+  assert.match(cliSource, /leaseExpired/);
+  assert.match(cliSource, /identityMismatch/);
 });

--- a/test/profiles.test.ts
+++ b/test/profiles.test.ts
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const configSource = readFileSync(new URL("../src/config.ts", import.meta.url), "utf8");
+const cliSource = readFileSync(new URL("../src/cli.ts", import.meta.url), "utf8");
+const updaterSource = readFileSync(new URL("../src/updater.ts", import.meta.url), "utf8");
+const cdpSource = readFileSync(new URL("../src/cdp.ts", import.meta.url), "utf8");
+const domSource = readFileSync(new URL("../src/dom.ts", import.meta.url), "utf8");
+const serviceSource = readFileSync(new URL("../src/service.ts", import.meta.url), "utf8");
+const launchIntegrationSource = readFileSync(new URL("../src/launch-integration.ts", import.meta.url), "utf8");
+const refreshSource = readFileSync(new URL("../scripts/refresh-local-install.mjs", import.meta.url), "utf8");
+const refreshInjectorSource = readFileSync(new URL("../scripts/refresh-injector.mjs", import.meta.url), "utf8");
+const developmentInstaller = readFileSync(new URL("../scripts/development-instance.mjs", import.meta.url), "utf8");
+const runtimeStateSource = readFileSync(new URL("../src/runtime-state.ts", import.meta.url), "utf8");
+
+test("stable and development profiles use isolated homes and one shared launch lock", () => {
+  assert.match(configSource, /BetterCodexProfile = "stable" \| "development"/);
+  assert.match(configSource, /"\.better-codex-dev" : "\.better-codex"/);
+  assert.match(configSource, /peerBetterCodexHome/);
+  assert.match(configSource, /"\.better-codex-launch\.lock"/);
+  assert.match(configSource, /"\.better-codex-launch-intents"/);
+});
+
+test("profile switching disables and stops the peer before injecting", () => {
+  const switchStart = cliSource.indexOf("async function deactivatePeerInstance()");
+  const launchStart = cliSource.indexOf('if (command === "launch")');
+  assert.ok(switchStart >= 0 && launchStart > switchStart);
+  assert.match(cliSource.slice(switchStart, launchStart), /disablePeerInjection/);
+  assert.match(cliSource.slice(switchStart, launchStart), /stopPeerInjector/);
+  assert.match(cliSource.slice(switchStart, launchStart), /stopPeerRuntime/);
+  assert.match(cliSource.slice(switchStart, launchStart), /stopPeerMacService/);
+  assert.ok(cliSource.slice(switchStart, launchStart).indexOf("const peerOwnership = injectionOwnership") < cliSource.slice(switchStart, launchStart).indexOf("stopPeerRuntime"));
+  assert.match(cliSource.slice(switchStart, launchStart), /cdpEject\(cdpPort, peerToken, peerOwnership\)/);
+  assert.ok(cliSource.slice(switchStart, launchStart).indexOf("cdpEject") < cliSource.slice(switchStart, launchStart).lastIndexOf("return null"));
+  assert.match(cliSource.slice(switchStart, launchStart), /peerInjectionState/);
+  assert.match(cliSource.slice(switchStart, launchStart), /injectionRemoved && !peerWasActive/);
+  assert.match(cliSource.slice(switchStart, launchStart), /injectionOwnership\(peerProfile, peerRunPath, true\)/);
+  assert.match(cliSource.slice(launchStart), /const switchedFrom = await deactivatePeerInstance\(\)/);
+  assert.match(cliSource, /function injectionOwnership/);
+  assert.match(cliSource, /cdpEject\(selectedPort, accessToken\(\), injectionOwnership\(\)\)/);
+  assert.match(cdpSource, /profile_not_active/);
+  assert.match(cliSource, /betterCodexProfile === "stable" && serviceStatus\(\)\.installed/);
+  assert.match(cdpSource, /betterCodexProfile === "development" && \(existing\.profile \?/);
+  assert.match(cdpSource, /setInjectionEnabled\(false\)/);
+  assert.match(cdpSource, /existing\.profile === betterCodexProfile/);
+  assert.match(cdpSource, /foreignDevelopmentInjection/);
+  assert.match(cdpSource, /await connection\.close\(\)/);
+  assert.match(cdpSource, /allowLegacyProfileless/);
+  assert.match(cdpSource, /recordInjectionOwnership/);
+  assert.doesNotMatch(cliSource, /setImmediate\(\(\) => process\.exit/);
+  assert.match(cliSource, /processStartTime/);
+  assert.match(cliSource, /injector_stop_failed/);
+  assert.match(runtimeStateSource, /startedAt: identity\.startedAt/);
+  assert.match(runtimeStateSource, /processStartTime\(current\.pid\)/);
+  assert.match(serviceSource, /betterCodexProfile === "development"/);
+  assert.match(serviceSource, /development_runtime_unmanaged/);
+});
+
+test("source builds refresh only the development instance", () => {
+  assert.match(refreshSource, /BETTER_CODEX_PROFILE: "development"/);
+  assert.match(refreshSource, /BETTER_CODEX_PEER_HOME: stableHome/);
+  assert.match(refreshSource, /"\.better-codex-dev"/);
+  assert.match(refreshSource, /if \(status\.runtime\?\.ok === true\)/);
+  assert.match(refreshSource, /if \(ownsInjection\) run\(\["start"\]\)/);
+  assert.match(developmentInstaller, /BETTER_CODEX_PROFILE: "development"/);
+  assert.match(developmentInstaller, /BETTER_CODEX_PEER_HOME: stableHome/);
+  assert.match(developmentInstaller, /\["launcher", "install"\]/);
+  assert.match(developmentInstaller, /stable_binary_required/);
+  assert.match(developmentInstaller, /BETTER_CODEX_STABLE_EXECUTABLE/);
+  assert.match(developmentInstaller, /Better Codex Launcher\.vbs/);
+  assert.match(developmentInstaller, /supportsProfiles \? "launch" : "start --launch"/);
+  assert.match(developmentInstaller, /dataPreserved: true/);
+  assert.match(refreshInjectorSource, /target\.endpoint === expectedEndpoint/);
+  assert.match(refreshInjectorSource, /\[executable, "refresh-injection"\]/);
+  assert.doesNotMatch(refreshInjectorSource, /\[executable, "eject"\]/);
+  assert.match(cliSource, /command === "refresh-injection"/);
+  assert.match(cliSource, /runtimeBeforeRefresh/);
+  assert.match(cliSource, /!runtimeBeforeRefresh && readRuntimeState\(\)/);
+});
+
+test("source mode does not advertise an unsupported core update", () => {
+  assert.match(updaterSource, /coreUpdateSupported: isSea\(\)/);
+  assert.match(updaterSource, /const coreAvailable = Boolean\(isSea\(\) && result\.core\?\.available\)/);
+  assert.match(domSource, /update\?\.coreUpdateSupported === false/);
+  assert.match(domSource, /源码开发版仅检查兼容层更新/);
+  assert.match(domSource, /profile: PROFILE/);
+});
+
+test("Windows shortcut status expands JSON arrays on Windows PowerShell 5.1", () => {
+  assert.match(launchIntegrationSource, /ConvertFrom-Json -InputObject \$json/);
+  assert.match(launchIntegrationSource, /\$items\[0\] -is \[Array\]/);
+});

--- a/test/version-sync.test.ts
+++ b/test/version-sync.test.ts
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const packageJson = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8")) as { version: string };
+const packageLock = JSON.parse(readFileSync(new URL("../package-lock.json", import.meta.url), "utf8")) as { packages: Record<string, { version?: string }> };
+const compatibilitySource = readFileSync(new URL("../src/compatibility.ts", import.meta.url), "utf8");
+const changelog = readFileSync(new URL("../CHANGELOG.md", import.meta.url), "utf8");
+const releaseWorkflow = readFileSync(new URL("../.github/workflows/release.yml", import.meta.url), "utf8");
+
+test("release version sources stay synchronized", () => {
+  const version = packageJson.version;
+  const coreVersion = compatibilitySource.match(/export const coreVersion = "([^"]+)"/)?.[1];
+  const escapedVersion = version.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  assert.match(version, /^\d+\.\d+\.\d+$/);
+  assert.equal(packageLock.packages[""].version, version);
+  assert.equal(coreVersion, version);
+  assert.match(changelog, new RegExp(`^## \\[${escapedVersion}\\] - \\d{4}-\\d{2}-\\d{2}$`, "m"));
+  assert.ok(changelog.includes(`[Unreleased]: https://github.com/Ericwong5021/better-codex/compare/v${version}...HEAD`));
+  assert.match(releaseWorkflow, /group: better-codex-release/);
+  assert.match(releaseWorkflow, /queue: max/);
+  assert.match(releaseWorkflow, /Refuse to downgrade the Homebrew formula/);
+  assert.match(releaseWorkflow, /git rebase origin\/main/);
+});


### PR DESCRIPTION
## Summary
- add isolated stable and development profiles with separate launchers and safe injection handoff
- add cross-platform packaged-installer compatibility gates, including reinstall coverage and Node 24 CDP lifecycle coverage
- prepare version 0.4.0 with synchronized release metadata and changelog

## Verification
- npm run build
- npm test (105 passing)
- npm run package:binary
- node scripts/test-local-install.mjs
- real stable-to-development handoff, including recovery from a legacy profileless injection with missing runtime state