### PR TITLE
feat: add native creator workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Better Codex are recorded here.
 
 ## [Unreleased]
 
+## [0.4.3-beta.5] - 2026-08-12
+
+### Added
+
+- Add an activatable creator workflow with dedicated Agents, native Codex conversation handoffs, approval gates, and a rounded workflow sidebar.
+
 ## [0.4.3-beta.4] - 2026-08-12
 
 ### Changed
@@ -376,7 +382,8 @@ All notable changes to Better Codex are recorded here.
 - Run Agent-owned Issues through an automated local workflow with visible review states.
 - Support macOS and Windows with a managed runtime, compatibility layer, signed updates, and release installers.
 
-[Unreleased]: https://github.com/Ericwong5021/better-codex/compare/v0.4.3-beta.4...HEAD
+[Unreleased]: https://github.com/Ericwong5021/better-codex/compare/v0.4.3-beta.5...HEAD
+[0.4.3-beta.5]: https://github.com/Ericwong5021/better-codex/compare/v0.4.3-beta.4...v0.4.3-beta.5
 [0.4.3-beta.4]: https://github.com/Ericwong5021/better-codex/compare/v0.4.3-beta.3...v0.4.3-beta.4
 [0.4.3-beta.3]: https://github.com/Ericwong5021/better-codex/compare/v0.4.3-beta.2...v0.4.3-beta.3
 [0.4.3-beta.2]: https://github.com/Ericwong5021/better-codex/compare/v0.4.3-beta.1...v0.4.3-beta.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "better-codex",
-  "version": "0.4.3-beta.4",
+  "version": "0.4.3-beta.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "better-codex",
-      "version": "0.4.3-beta.4",
+      "version": "0.4.3-beta.5",
       "license": "Apache-2.0",
       "dependencies": {
         "lucide-static": "^1.28.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "better-codex",
-  "version": "0.4.3-beta.4",
+  "version": "0.4.3-beta.5",
   "private": true,
   "license": "Apache-2.0",
   "type": "module",

--- a/src/compatibility.ts
+++ b/src/compatibility.ts
@@ -2,7 +2,7 @@ import { existsSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { compatibilityCurrentPath, compatibilityStatusPath, compatibilityVersionsPath, ensureDirectories, runtimeCurrentPath } from "./config.js";
 
-export const coreVersion = "0.4.3-beta.4";
+export const coreVersion = "0.4.3-beta.5";
 
 export type CompatibilityManifest = {
   version: string;

--- a/src/db.ts
+++ b/src/db.ts
@@ -4,6 +4,7 @@ import { dirname, join, resolve } from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { databasePath, developmentDatabaseSnapshotSourcePath } from "./config.js";
 import { syncProtocolVersion } from "./sync-contract.js";
+import { workflowTemplate } from "./workflows.js";
 import type { ConversationProjection, IssueProjection, ProjectProjection, RemoteCommand, RemoteCommandAck, SyncEntityType, SyncProjection } from "./sync-contract.js";
 
 export const issueStatuses = ["backlog", "todo", "in_progress", "in_review", "done", "blocked", "cancelled"] as const;
@@ -151,6 +152,31 @@ export type SchedulerDecision = {
   evidence: string[];
 };
 
+export type WorkflowRun = {
+  id: string;
+  template_id: string;
+  template_version: number;
+  title: string;
+  brief: string;
+  project_id: string;
+  workspace_path: string;
+  status: "active" | "completed" | "cancelled";
+  created_at: string;
+  updated_at: string;
+  nodes: Array<{
+    node_id: string;
+    issue_id: string;
+    issue: Issue;
+  }>;
+};
+
+export type WorkflowActivation = {
+  template_id: string;
+  template_version: number;
+  activated_at: string;
+  agents: Array<{ template_agent_id: string; agent_id: string; agent: AgentProfile }>;
+};
+
 export type PendingSchedulerRun = {
   claim: ClaimedIssue;
   executionSuccess: boolean;
@@ -208,7 +234,7 @@ export function cleanMaxConcurrency(value: number | undefined) {
   return value;
 }
 
-const latestSchemaVersion = 6;
+const latestSchemaVersion = 8;
 
 function now() {
   return new Date().toISOString();
@@ -577,6 +603,62 @@ export class Store {
           );
         `);
         this.db.prepare("INSERT INTO schema_migrations (version, applied_at) VALUES (6, ?)").run(now());
+        this.db.exec("COMMIT");
+      } catch (error) {
+        this.db.exec("ROLLBACK");
+        throw error;
+      }
+    }
+    if (fromVersion < 7) {
+      this.db.exec("BEGIN IMMEDIATE");
+      try {
+        this.db.exec(`
+          CREATE TABLE IF NOT EXISTS workflow_runs (
+            id TEXT PRIMARY KEY,
+            template_id TEXT NOT NULL,
+            template_version INTEGER NOT NULL,
+            title TEXT NOT NULL,
+            brief TEXT NOT NULL DEFAULT '',
+            project_id TEXT NOT NULL REFERENCES projects(id),
+            workspace_path TEXT NOT NULL DEFAULT '',
+            status TEXT NOT NULL DEFAULT 'active',
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+          );
+          CREATE TABLE IF NOT EXISTS workflow_node_runs (
+            workflow_run_id TEXT NOT NULL REFERENCES workflow_runs(id) ON DELETE CASCADE,
+            node_id TEXT NOT NULL,
+            issue_id TEXT NOT NULL UNIQUE REFERENCES issues(id) ON DELETE CASCADE,
+            created_at TEXT NOT NULL,
+            PRIMARY KEY (workflow_run_id, node_id)
+          );
+          CREATE INDEX IF NOT EXISTS workflow_runs_project_updated ON workflow_runs(project_id, updated_at DESC);
+          CREATE INDEX IF NOT EXISTS workflow_node_runs_issue ON workflow_node_runs(issue_id);
+        `);
+        this.db.prepare("INSERT INTO schema_migrations (version, applied_at) VALUES (7, ?)").run(now());
+        this.db.exec("COMMIT");
+      } catch (error) {
+        this.db.exec("ROLLBACK");
+        throw error;
+      }
+    }
+    if (fromVersion < 8) {
+      this.db.exec("BEGIN IMMEDIATE");
+      try {
+        this.db.exec(`
+          CREATE TABLE IF NOT EXISTS workflow_activations (
+            template_id TEXT PRIMARY KEY,
+            template_version INTEGER NOT NULL,
+            activated_at TEXT NOT NULL
+          );
+          CREATE TABLE IF NOT EXISTS workflow_activation_agents (
+            template_id TEXT NOT NULL REFERENCES workflow_activations(template_id) ON DELETE CASCADE,
+            template_agent_id TEXT NOT NULL,
+            agent_id TEXT NOT NULL REFERENCES agent_profiles(id),
+            PRIMARY KEY (template_id, template_agent_id)
+          );
+        `);
+        this.db.prepare("INSERT INTO schema_migrations (version, applied_at) VALUES (8, ?)").run(now());
         this.db.exec("COMMIT");
       } catch (error) {
         this.db.exec("ROLLBACK");
@@ -1627,7 +1709,229 @@ export class Store {
     return this.getIssue(id)!;
   }
 
-  updateIssue(id: string, version: number, patch: IssuePatch) {
+  createWorkflowRun(input: { templateId: string; title: string; brief: string; projectId: string; workspacePath?: string }) {
+    const template = workflowTemplate(input.templateId);
+    if (!template) throw new Error("workflow_template_not_found");
+    const activation = this.getWorkflowActivation(template.id);
+    if (!activation) throw new Error("workflow_not_activated");
+    const agentIds = new Map(activation.agents.map(item => [item.template_agent_id, item.agent_id]));
+    if (template.agents.some(agent => !agentIds.has(agent.id))) throw new Error("workflow_agents_missing");
+    const project = this.getProject(input.projectId);
+    if (!project) throw new Error("project_not_found");
+    const title = cleanTitle(input.title);
+    const brief = input.brief.trim();
+    if (!brief) throw new Error("workflow_brief_required");
+    if (brief.length > 100000) throw new Error("workflow_brief_too_long");
+    const workspacePath = input.workspacePath?.trim() || project.workspace_path;
+    if (!workspacePath) throw new Error("workspace_required");
+    const runId = randomUUID();
+    const timestamp = now();
+    const issues = new Map<string, Issue>();
+    const createdIssueIds: string[] = [];
+    try {
+      for (const node of template.nodes) {
+        const dependencyLines = node.dependencies.map(dependencyId => {
+          const dependency = issues.get(dependencyId);
+          return dependency ? `- ${dependency.identifier} · ${dependency.title}` : "";
+        }).filter(Boolean);
+        const description = [
+          `工作流：${title}`,
+          `职责：${node.role}`,
+          "",
+          `本轮输入：${brief}`,
+          dependencyLines.length ? `\n上游会话：\n${dependencyLines.join("\n")}` : "",
+          "",
+          node.prompt,
+        ].filter(Boolean).join("\n");
+        const unlocked = node.dependencies.length === 0;
+        const issue = this.createIssue({
+          projectId: project.id,
+          title: node.title,
+          description,
+          status: unlocked ? "todo" : "backlog",
+          priority: node.kind === "gate" ? "high" : "medium",
+          labels: ["workflow", template.category, runId.slice(0, 8)],
+          workspacePath,
+          agentEnabled: unlocked && node.kind === "agent",
+          agentId: node.agent ? agentIds.get(node.agent) : undefined,
+          userAssigned: unlocked && node.kind === "gate",
+        });
+        issues.set(node.id, issue);
+        createdIssueIds.push(issue.id);
+      }
+      this.db.exec("BEGIN IMMEDIATE");
+      this.db.prepare(`
+        INSERT INTO workflow_runs (id, template_id, template_version, title, brief, project_id, workspace_path, status, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, 'active', ?, ?)
+      `).run(runId, template.id, template.version, title, brief, project.id, workspacePath, timestamp, timestamp);
+      const insertNode = this.db.prepare("INSERT INTO workflow_node_runs (workflow_run_id, node_id, issue_id, created_at) VALUES (?, ?, ?, ?)");
+      for (const node of template.nodes) insertNode.run(runId, node.id, issues.get(node.id)!.id, timestamp);
+      this.db.exec("COMMIT");
+    } catch (error) {
+      try { this.db.exec("ROLLBACK"); } catch {}
+      for (const issueId of createdIssueIds) this.db.prepare("DELETE FROM issues WHERE id = ?").run(issueId);
+      throw error;
+    }
+    return this.getWorkflowRun(runId)!;
+  }
+
+  getWorkflowRun(id: string): WorkflowRun | undefined {
+    const row = this.db.prepare("SELECT * FROM workflow_runs WHERE id = ?").get(id) as Record<string, unknown> | undefined;
+    if (!row) return undefined;
+    const nodes = this.db.prepare("SELECT node_id, issue_id FROM workflow_node_runs WHERE workflow_run_id = ? ORDER BY created_at, rowid").all(id) as Array<{ node_id: string; issue_id: string }>;
+    return {
+      id: String(row.id),
+      template_id: String(row.template_id),
+      template_version: Number(row.template_version),
+      title: String(row.title),
+      brief: String(row.brief),
+      project_id: String(row.project_id),
+      workspace_path: String(row.workspace_path),
+      status: String(row.status) as WorkflowRun["status"],
+      created_at: String(row.created_at),
+      updated_at: String(row.updated_at),
+      nodes: nodes.flatMap(node => {
+        const issue = this.getIssue(node.issue_id);
+        return issue ? [{ node_id: node.node_id, issue_id: node.issue_id, issue }] : [];
+      }),
+    };
+  }
+
+  listWorkflowRuns(projectId?: string) {
+    const rows = projectId
+      ? this.db.prepare("SELECT id FROM workflow_runs WHERE project_id = ? ORDER BY updated_at DESC").all(projectId)
+      : this.db.prepare("SELECT id FROM workflow_runs ORDER BY updated_at DESC").all();
+    return (rows as Array<{ id: string }>).flatMap(row => {
+      const run = this.getWorkflowRun(row.id);
+      return run ? [run] : [];
+    });
+  }
+
+  getWorkflowActivation(templateId: string): WorkflowActivation | undefined {
+    const row = this.db.prepare("SELECT * FROM workflow_activations WHERE template_id = ?").get(templateId) as { template_id: string; template_version: number; activated_at: string } | undefined;
+    if (!row) return undefined;
+    const agents = this.db.prepare("SELECT template_agent_id, agent_id FROM workflow_activation_agents WHERE template_id = ? ORDER BY rowid").all(templateId) as Array<{ template_agent_id: string; agent_id: string }>;
+    return {
+      template_id: row.template_id,
+      template_version: Number(row.template_version),
+      activated_at: row.activated_at,
+      agents: agents.flatMap(item => {
+        const agent = this.getAgentProfile(item.agent_id);
+        return agent ? [{ ...item, agent }] : [];
+      }),
+    };
+  }
+
+  listWorkflowActivations() {
+    const rows = this.db.prepare("SELECT template_id FROM workflow_activations ORDER BY activated_at").all() as Array<{ template_id: string }>;
+    return rows.flatMap(row => {
+      const activation = this.getWorkflowActivation(row.template_id);
+      return activation ? [activation] : [];
+    });
+  }
+
+  workflowActivationForAgent(agentId: string) {
+    return this.db.prepare("SELECT template_id, template_agent_id FROM workflow_activation_agents WHERE agent_id = ?").get(agentId) as { template_id: string; template_agent_id: string } | undefined;
+  }
+
+  activateWorkflow(templateId: string, agentDefaults: { model: string; reasoning_effort: string; sandbox_mode: AgentSandboxMode }) {
+    const template = workflowTemplate(templateId);
+    if (!template) throw new Error("workflow_template_not_found");
+    const current = this.getWorkflowActivation(template.id);
+    if (current) return current;
+    const timestamp = now();
+    this.db.exec("BEGIN IMMEDIATE");
+    try {
+      const createdAgents: AgentProfile[] = [];
+      for (const agent of template.agents) {
+        const profile = this.createAgentProfile({
+          name: agent.name,
+          name_en: agent.name_en,
+          description: agent.description,
+          instructions: agent.instructions,
+          model: agentDefaults.model,
+          reasoning_effort: agentDefaults.reasoning_effort,
+          sandbox_mode: agentDefaults.sandbox_mode,
+          max_concurrency: 1,
+        });
+        this.setAgentAvatar(profile.id, agent.avatar);
+        createdAgents.push(profile);
+      }
+      this.db.prepare("INSERT INTO workflow_activations (template_id, template_version, activated_at) VALUES (?, ?, ?)").run(template.id, template.version, timestamp);
+      const insertAgent = this.db.prepare("INSERT INTO workflow_activation_agents (template_id, template_agent_id, agent_id) VALUES (?, ?, ?)");
+      template.agents.forEach((agent, index) => insertAgent.run(template.id, agent.id, createdAgents[index].id));
+      this.db.exec("COMMIT");
+    } catch (error) {
+      this.db.exec("ROLLBACK");
+      throw error;
+    }
+    return this.getWorkflowActivation(template.id)!;
+  }
+
+  workflowRunForIssue(issueId: string) {
+    const row = this.db.prepare("SELECT workflow_run_id FROM workflow_node_runs WHERE issue_id = ?").get(issueId) as { workflow_run_id: string } | undefined;
+    return row ? this.getWorkflowRun(row.workflow_run_id) : undefined;
+  }
+
+  private workflowIssueOutput(issue: Issue) {
+    const session = this.db.prepare("SELECT last_agent_message FROM issue_sessions WHERE issue_id = ?").get(issue.id) as { last_agent_message: string } | undefined;
+    if (session?.last_agent_message.trim()) return session.last_agent_message.trim();
+    const run = this.db.prepare("SELECT execution_result FROM issue_runs WHERE issue_id = ? AND execution_result IS NOT NULL ORDER BY started_at DESC LIMIT 1").get(issue.id) as { execution_result: string } | undefined;
+    if (run?.execution_result.trim()) return run.execution_result.trim();
+    return issue.description.trim();
+  }
+
+  advanceWorkflowForIssue(issueId: string) {
+    const run = this.workflowRunForIssue(issueId);
+    if (!run || run.status !== "active") return [] as Issue[];
+    const template = workflowTemplate(run.template_id);
+    if (!template) return [] as Issue[];
+    const activation = this.getWorkflowActivation(template.id);
+    if (!activation) return [] as Issue[];
+    const agentIds = new Map(activation.agents.map(item => [item.template_agent_id, item.agent_id]));
+    if (template.agents.some(agent => !agentIds.has(agent.id))) return [] as Issue[];
+    const issueByNode = new Map(run.nodes.map(node => [node.node_id, node.issue]));
+    const activated: Issue[] = [];
+    for (const node of template.nodes) {
+      const issue = issueByNode.get(node.id);
+      if (!issue || issue.status !== "backlog") continue;
+      const dependencies = node.dependencies.map(dependencyId => issueByNode.get(dependencyId)).filter((value): value is Issue => Boolean(value));
+      if (dependencies.length !== node.dependencies.length || dependencies.some(dependency => dependency.status !== "done")) continue;
+      const handoff = dependencies.map(dependency => `## ${dependency.identifier} · ${dependency.title}\n${this.workflowIssueOutput(dependency)}`).join("\n\n").slice(0, 80000);
+      const description = `${issue.description}\n\n上游会话结果：\n${handoff}`;
+      const updated = this.updateIssue(issue.id, issue.version, {
+        description,
+        status: "todo",
+        agent_enabled: node.kind === "agent",
+        agent_id: node.agent ? agentIds.get(node.agent) : null,
+        user_assigned: node.kind === "gate",
+        pending_actor: node.kind === "agent" ? "agent" : "user",
+        needs_attention: true,
+      }, { unlockWorkflowNode: true });
+      issueByNode.set(node.id, updated);
+      activated.push(updated);
+    }
+    const currentIssues = template.nodes.map(node => issueByNode.get(node.id)).filter((value): value is Issue => Boolean(value));
+    if (currentIssues.length === template.nodes.length && currentIssues.every(issue => issue.status === "done")) {
+      this.db.prepare("UPDATE workflow_runs SET status = 'completed', updated_at = ? WHERE id = ?").run(now(), run.id);
+    } else if (activated.length) {
+      this.db.prepare("UPDATE workflow_runs SET updated_at = ? WHERE id = ?").run(now(), run.id);
+    }
+    return activated;
+  }
+
+  workflowNodeLocked(issueId: string) {
+    const row = this.db.prepare(`
+      SELECT issues.status, workflow_runs.status AS workflow_status
+      FROM workflow_node_runs
+      JOIN workflow_runs ON workflow_runs.id = workflow_node_runs.workflow_run_id
+      JOIN issues ON issues.id = workflow_node_runs.issue_id
+      WHERE workflow_node_runs.issue_id = ?
+    `).get(issueId) as { status: IssueStatus; workflow_status: WorkflowRun["status"] } | undefined;
+    return Boolean(row && row.workflow_status === "active" && row.status === "backlog");
+  }
+
+  updateIssue(id: string, version: number, patch: IssuePatch, options: { unlockWorkflowNode?: boolean } = {}) {
     const pendingActorProvided = patch.pending_actor !== undefined;
     if (!Number.isInteger(version) || version < 1) throw new Error("invalid_version");
     if (patch.title !== undefined) patch.title = cleanTitle(patch.title);
@@ -1643,6 +1947,7 @@ export class Store {
       const issue = this.getIssue(id);
       if (!issue) throw new Error("issue_not_found");
       if (issue.version !== version) throw new Error("version_conflict");
+      if (!options.unlockWorkflowNode && this.workflowNodeLocked(issue.id) && patch.status !== undefined && patch.status !== "backlog") throw new Error("workflow_node_locked");
       if (issue.enrichment_status === "pending" && patch.enrichment_status === undefined) throw new Error("issue_enrichment_pending");
       if ((issue.run_thread_id || issue.active_run_status) && (patch.title !== undefined || patch.description !== undefined)) throw new Error("issue_execution_locked");
       if (patch.project_id !== undefined && !this.getProject(patch.project_id)) throw new Error("project_not_found");

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -285,6 +285,7 @@ export function injectionScript(port: number, accessToken: string, action: "inst
 
     const ENTRY_ID = "better-codex-entry";
     const AGENTS_ENTRY_ID = "better-codex-agents-entry";
+    const WORKFLOWS_ENTRY_ID = "better-codex-workflows-entry";
     const PANEL_ID = "better-codex-panel";
     const STYLE_ID = "better-codex-style";
     const OWNED = "data-better-codex-owned";
@@ -349,7 +350,7 @@ export function injectionScript(port: number, accessToken: string, action: "inst
     }
     const systemLocale = resolveSystemLocale(INITIAL_LOCALE);
     const MOCKUP_PROJECT_ID = "mockup-better-codex";
-    const state = { projects: [], issues: [], agents: [], agentModelCatalog: [], agentModels: [], agentReasoningEfforts: [], user: { id: "", name: "你", email: "", handle: "", initials: "你", color: "#16a34a" }, projectId: "", search: "", agentSearch: "", agentView: "all", agentPane: "preview", selectedAgentId: "", agentDraft: null, agentInspectorWidth: Number.isFinite(rememberedAgentInspectorWidth) && rememberedAgentInspectorWidth > 0 ? rememberedAgentInspectorWidth : 0, surface: ["issues", "agents"].includes(rememberedSurface) ? rememberedSurface : "issues", view: "all", autoDispatch: false, schedulerModel: "gpt-5.6-sol", schedulerReasoningEffort: "high", mockup: false, keepCreate: false, selected: null, error: "", systemLocale, languageSetting, locale: languageSetting === "system" ? systemLocale : languageSetting, filters: { status: [], priority: [], date: [], assignee: [], creator: [], project: [], label: [] } };
+    const state = { projects: [], issues: [], agents: [], workflowTemplates: [], workflowActivations: [], workflowRuns: [], expandedWorkflowTemplateId: "", selectedWorkflowRunId: "", agentModelCatalog: [], agentModels: [], agentReasoningEfforts: [], user: { id: "", name: "你", email: "", handle: "", initials: "你", color: "#16a34a" }, projectId: "", search: "", agentSearch: "", agentView: "all", agentPane: "preview", selectedAgentId: "", agentDraft: null, agentInspectorWidth: Number.isFinite(rememberedAgentInspectorWidth) && rememberedAgentInspectorWidth > 0 ? rememberedAgentInspectorWidth : 0, surface: ["issues", "agents", "workflows"].includes(rememberedSurface) ? rememberedSurface : "issues", view: "all", autoDispatch: false, schedulerModel: "gpt-5.6-sol", schedulerReasoningEffort: "high", mockup: false, keepCreate: false, selected: null, error: "", systemLocale, languageSetting, locale: languageSetting === "system" ? systemLocale : languageSetting, filters: { status: [], priority: [], date: [], assignee: [], creator: [], project: [], label: [] } };
     function shortcutKeyFromCode(code, key) {
       const source = String(code || "");
       if (/^Key[A-Z]$/.test(source)) return source.slice(3);
@@ -527,6 +528,47 @@ export function injectionScript(port: number, accessToken: string, action: "inst
     localeResources.en["原生会话正在创建，请稍后重试。"] = "The native conversation is being created. Try again shortly.";
     localeResources.en["停止任务"] = "Stop task";
     localeResources.en["正在停止…"] = "Stopping…";
+    Object.assign(localeResources.en, {
+      "工作流": "Workflows",
+      "打开工作流": "Open workflows",
+      "用原生 Codex 会话完成跨 Agent 协作": "Coordinate agents through native Codex conversations",
+      "个节点": "nodes",
+      "个 Agent 会话": "agent conversations",
+      "含人工审批": "Human approvals",
+      "使用模板": "Use template",
+      "运行记录": "Runs",
+      "暂无工作流模板": "No workflow templates",
+      "还没有运行。填写本轮主题后即可启动第一个研究会话。": "No runs yet. Add a campaign brief to start the first research conversation.",
+      "等待中": "Waiting",
+      "等待上游": "Waiting for upstream",
+      "等待确认": "Awaiting approval",
+      "待开始": "Ready",
+      "就绪": "Ready",
+      "打开会话": "Open conversation",
+      "进行中": "Active",
+      "Campaign 名称": "Campaign name",
+      "新一轮内容 Campaign": "New creator campaign",
+      "本轮输入": "Campaign brief",
+      "写下产品事实、目标受众、想解决的问题、已有素材和目标平台。": "Add product facts, audience, problem, available assets and target channels.",
+      "启动研究会话": "Start research conversation",
+      "个专属 Agent": "dedicated agents",
+      "已激活": "Activated",
+      "未激活": "Not activated",
+      "激活工作流": "Activate workflow",
+      "新建 Campaign": "New campaign",
+      "工作流已就绪": "Workflow ready",
+      "激活后创建专属 Agent": "Dedicated agents are created on activation",
+      "可以创建 Campaign，每个节点会使用已绑定的专属 Agent。": "You can create campaigns. Each node uses its assigned agent.",
+      "确认后会创建模板运行所需的 Agent，现有 Agent 不会被修改。": "The required agents will be created after confirmation. Existing agents stay unchanged.",
+      "还没有运行。创建 Campaign 后会启动第一个研究会话。": "No runs yet. Creating a campaign starts the first research conversation.",
+      "激活工作流后才能创建 Campaign。": "Activate the workflow before creating a campaign.",
+      "这个工作流需要创建以下专属 Agent。它们会出现在智能体列表中，并由对应节点自动使用。": "This workflow creates the dedicated agents below. They appear in the agent list and are assigned to their workflow nodes.",
+      "确认并创建 Agent": "Confirm and create agents",
+      "工作流尚未激活。": "Activate the workflow before creating a campaign.",
+      "工作流所需 Agent 不完整，请重新激活。": "Some workflow agents are missing. Reactivate the workflow.",
+      "当前没有可用于创建 Agent 的模型。": "No model is available for creating workflow agents.",
+      "该 Agent 正被已激活的工作流使用，无法删除。": "This agent belongs to an active workflow and cannot be deleted.",
+    });
     const bridgeRequests = new Map();
     const appServerRequests = new Map();
     const sessionHandoffPending = new Set();
@@ -537,6 +579,7 @@ export function injectionScript(port: number, accessToken: string, action: "inst
     let diagnosticSequence = 0;
     let entry = null;
     let agentsEntry = null;
+    let workflowsEntry = null;
     let panel = null;
     let observer = null;
     let refreshPending = false;
@@ -732,9 +775,9 @@ export function injectionScript(port: number, accessToken: string, action: "inst
       style.id = STYLE_ID;
       style.setAttribute(OWNED, "true");
       style.textContent = \`
-        #\${ENTRY_ID}[aria-current="page"], #\${AGENTS_ENTRY_ID}[aria-current="page"] { background: var(--color-background-primary-soft-active, var(--color-token-list-hover-background, color-mix(in srgb, currentColor 8%, transparent))); }
-        html[data-better-codex-open="true"] \${SELECTORS.sidebarNavigation} [aria-current="page"]:not(#\${ENTRY_ID}):not(#\${AGENTS_ENTRY_ID}) { background: transparent !important; }
-        html[data-better-codex-open="true"] \${SELECTORS.sidebarNavigation} [aria-current="page"]:not(#\${ENTRY_ID}):not(#\${AGENTS_ENTRY_ID}) .text-token-list-active-selection-foreground { color: var(--color-token-foreground) !important; }
+        #\${ENTRY_ID}[aria-current="page"], #\${AGENTS_ENTRY_ID}[aria-current="page"], #\${WORKFLOWS_ENTRY_ID}[aria-current="page"] { background: var(--color-background-primary-soft-active, var(--color-token-list-hover-background, color-mix(in srgb, currentColor 8%, transparent))); }
+        html[data-better-codex-open="true"] \${SELECTORS.sidebarNavigation} [aria-current="page"]:not(#\${ENTRY_ID}):not(#\${AGENTS_ENTRY_ID}):not(#\${WORKFLOWS_ENTRY_ID}) { background: transparent !important; }
+        html[data-better-codex-open="true"] \${SELECTORS.sidebarNavigation} [aria-current="page"]:not(#\${ENTRY_ID}):not(#\${AGENTS_ENTRY_ID}):not(#\${WORKFLOWS_ENTRY_ID}) .text-token-list-active-selection-foreground { color: var(--color-token-foreground) !important; }
         [\${HOST}="true"] { position: relative !important; z-index: 31 !important; pointer-events: none !important; }
         [\${HIDDEN}="true"] { visibility: hidden !important; pointer-events: none !important; }
         html { --bc-page: oklch(.988087 0 0); --bc-surface: oklch(1 0 0); --bc-raised: oklch(1 0 0); --bc-hover: oklch(.967 .001 286.375); --bc-selected: oklch(.95 .002 286.375); --bc-foreground: oklch(.141 .005 285.823); --bc-muted: oklch(.505 .016 285.938); --bc-faint: oklch(.606 .016 285.938); --bc-border: oklch(.92 .004 286.32); --bc-divider: oklch(.945 .003 286.32); --bc-input: oklch(.92 .004 286.32); --bc-ring: oklch(.705 .015 286.067); --bc-primary: oklch(.21 .006 285.885); --bc-primary-foreground: oklch(.985 0 0); --bc-warning: oklch(.75 .16 85); --bc-success: oklch(.55 .16 145); --bc-info: oklch(.55 .18 250); --bc-danger: oklch(.577 .245 27.325); --bc-priority-none: oklch(.62 .01 286); --bc-priority-low: oklch(.55 .1 250); --bc-priority-medium: oklch(.76 .15 95); --bc-priority-high: oklch(.68 .18 52); --bc-priority-urgent: var(--bc-danger); --bc-surface-shadow: 0 1px 2px rgb(15 23 42 / .04),0 1px 1px rgb(15 23 42 / .03); --bc-card-shadow: 0 1px 3px rgb(15 23 42 / .10); --bc-floating-shadow: 0 16px 40px rgb(15 23 42 / .14),0 3px 10px rgb(15 23 42 / .08); --bc-menu-shadow: 0 8px 24px rgb(15 23 42 / .08),0 2px 6px rgb(15 23 42 / .05); --bc-scrim: rgb(24 24 27 / .22); color-scheme: light; }
@@ -905,6 +948,87 @@ export function injectionScript(port: number, accessToken: string, action: "inst
         #\${PANEL_ID}[data-surface="agents"] .better-codex-agent-heading, #\${PANEL_ID}[data-surface="agents"] .better-codex-agent-actions { display: flex; }
         #\${PANEL_ID} .better-codex-agents { display: none; min-height: 0; flex: 1; overflow-y: auto; padding: 12px 22px 28px; }
         #\${PANEL_ID}[data-surface="agents"] .better-codex-agents { display: block; }
+        #\${PANEL_ID}[data-surface="workflows"] .better-codex-issue-only, #\${PANEL_ID}[data-surface="workflows"] .better-codex-agent-heading, #\${PANEL_ID}[data-surface="workflows"] .better-codex-agent-actions { display: none; }
+        #\${PANEL_ID}[data-surface="workflows"] .better-codex-toolbar { display: none; }
+        #\${PANEL_ID} .better-codex-workflows { display: none; min-height: 0; flex: 1; overflow-y: auto; background: var(--bc-page); padding: 24px; }
+        #\${PANEL_ID}[data-surface="workflows"] .better-codex-workflows { display: block; }
+        #\${PANEL_ID} .better-codex-workflow-shell { width: min(1120px,100%); margin: 0 auto; }
+        #\${PANEL_ID} .better-codex-workflow-heading { display: flex; align-items: end; justify-content: space-between; gap: 20px; margin-bottom: 20px; }
+        #\${PANEL_ID} .better-codex-workflow-heading h1 { margin: 0; color: var(--bc-foreground); font-size: 22px; letter-spacing: -.025em; }
+        #\${PANEL_ID} .better-codex-workflow-heading p { margin: 5px 0 0; color: var(--bc-muted); font-size: var(--bc-text-md); }
+        #\${PANEL_ID} .better-codex-workflow-layout { display: grid; grid-template-columns: minmax(0,1fr) 292px; gap: 18px; align-items: start; }
+        #\${PANEL_ID} .better-codex-workflow-main, #\${PANEL_ID} .better-codex-workflow-aside { border: 0; border-radius: 20px; background: var(--bc-surface); box-shadow: var(--bc-card-shadow); }
+        #\${PANEL_ID} .better-codex-workflow-main { overflow: hidden; transition: transform .16s cubic-bezier(.16,1,.3,1),background-color .16s; }
+        #\${PANEL_ID} .better-codex-workflow-main:active { transform: scale(.995); }
+        #\${PANEL_ID} .better-codex-workflow-template-head { display: flex; width: 100%; box-sizing: border-box; align-items: flex-start; gap: 14px; border: 0; color: inherit; background: transparent; padding: 20px; text-align: left; cursor: pointer; }
+        #\${PANEL_ID} .better-codex-workflow-template-head:focus-visible { outline: 2px solid var(--bc-ring); outline-offset: -3px; }
+        #\${PANEL_ID} .better-codex-workflow-template-icon { display: inline-flex; width: 40px; height: 40px; flex: 0 0 auto; align-items: center; justify-content: center; border-radius: 13px; color: var(--bc-foreground); background: var(--bc-hover); }
+        #\${PANEL_ID} .better-codex-workflow-template-icon svg { width: 18px; height: 18px; }
+        #\${PANEL_ID} .better-codex-workflow-template-copy { min-width: 0; flex: 1; }
+        #\${PANEL_ID} .better-codex-workflow-template-copy h2 { margin: 0; color: var(--bc-foreground); font-size: var(--bc-text-lg); }
+        #\${PANEL_ID} .better-codex-workflow-template-copy p { margin: 5px 0 0; color: var(--bc-muted); font-size: var(--bc-text-sm); line-height: 1.55; }
+        #\${PANEL_ID} .better-codex-workflow-template-meta { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 10px; }
+        #\${PANEL_ID} .better-codex-workflow-template-meta span { border-radius: 999px; color: var(--bc-muted); background: var(--bc-hover); padding: 3px 7px; font-size: var(--bc-text-caption); }
+        #\${PANEL_ID} .better-codex-workflow-template-meta .is-active { color: var(--bc-success); background: color-mix(in srgb,var(--bc-success) 10%,var(--bc-hover)); }
+        #\${PANEL_ID} .better-codex-workflow-chevron { display: inline-flex; width: 32px; height: 32px; flex: 0 0 auto; align-items: center; justify-content: center; border-radius: 999px; color: var(--bc-muted); background: var(--bc-hover); transition: transform .18s cubic-bezier(.16,1,.3,1); }
+        #\${PANEL_ID} .better-codex-workflow-main.is-expanded .better-codex-workflow-chevron { transform: rotate(90deg); }
+        #\${PANEL_ID} .better-codex-workflow-detail { display: none; padding: 2px 20px 20px; }
+        #\${PANEL_ID} .better-codex-workflow-main.is-expanded .better-codex-workflow-detail { display: block; animation: better-codex-workflow-reveal .18s cubic-bezier(.16,1,.3,1); }
+        @keyframes better-codex-workflow-reveal { from { opacity: 0; transform: translateY(-6px); } to { opacity: 1; transform: translateY(0); } }
+        #\${PANEL_ID} .better-codex-workflow-detail-head { display: flex; align-items: center; justify-content: space-between; gap: 16px; border-radius: 16px; background: var(--bc-page); padding: 14px 16px; }
+        #\${PANEL_ID} .better-codex-workflow-detail-head strong { display: block; color: var(--bc-foreground); font-size: var(--bc-text-sm); }
+        #\${PANEL_ID} .better-codex-workflow-detail-head span { display: block; margin-top: 3px; color: var(--bc-muted); font-size: var(--bc-text-caption); }
+        #\${PANEL_ID} .better-codex-workflow-start { min-height: 40px; flex: 0 0 auto; border: 0; border-radius: 10px; color: var(--bc-primary-foreground); background: var(--bc-primary); padding: 0 14px; font: inherit; font-size: var(--bc-text-sm); font-weight: 600; cursor: pointer; transition: transform .14s; }
+        #\${PANEL_ID} .better-codex-workflow-start:active { transform: scale(.96); }
+        #\${PANEL_ID} .better-codex-workflow-start:disabled { opacity: .48; cursor: default; transform: none; }
+        #\${PANEL_ID} .better-codex-workflow-nodes { display: grid; gap: 6px; padding-top: 12px; }
+        #\${PANEL_ID} .better-codex-workflow-node { position: relative; display: grid; grid-template-columns: 28px minmax(0,1fr) auto; gap: 10px; align-items: center; min-height: 52px; border: 0; border-radius: 14px; background: var(--bc-page); padding: 0 12px; }
+        #\${PANEL_ID} .better-codex-workflow-node-mark { display: inline-flex; width: 22px; height: 22px; align-items: center; justify-content: center; border: 0; border-radius: 999px; color: var(--bc-muted); background: var(--bc-surface); }
+        #\${PANEL_ID} .better-codex-workflow-node-mark svg { width: 12px; height: 12px; }
+        #\${PANEL_ID} .better-codex-workflow-node-copy { min-width: 0; }
+        #\${PANEL_ID} .better-codex-workflow-node-copy strong { display: block; color: var(--bc-foreground); font-size: var(--bc-text-sm); font-weight: 600; }
+        #\${PANEL_ID} .better-codex-workflow-node-copy span { display: block; margin-top: 2px; overflow: hidden; color: var(--bc-muted); font-size: var(--bc-text-caption); text-overflow: ellipsis; white-space: nowrap; }
+        #\${PANEL_ID} .better-codex-workflow-node-state { color: var(--bc-muted); font-size: var(--bc-text-caption); }
+        #\${PANEL_ID} button.better-codex-workflow-node-state { border: 0; color: var(--bc-info); background: transparent; padding: 5px; font: inherit; font-size: var(--bc-text-caption); cursor: pointer; }
+        #\${PANEL_ID} .better-codex-workflow-node[data-status="done"] .better-codex-workflow-node-mark { color: var(--bc-success); }
+        #\${PANEL_ID} .better-codex-workflow-node[data-status="in_progress"] .better-codex-workflow-node-mark { color: var(--bc-warning); }
+        #\${PANEL_ID} .better-codex-workflow-node[data-status="blocked"] .better-codex-workflow-node-mark { color: var(--bc-danger); }
+        #\${PANEL_ID} .better-codex-workflow-aside { overflow: hidden; padding: 8px; }
+        #\${PANEL_ID} .better-codex-workflow-aside h3 { margin: 0; border: 0; padding: 8px 9px 10px; color: var(--bc-foreground); font-size: var(--bc-text-md); }
+        #\${PANEL_ID} .better-codex-workflow-run { display: block; width: 100%; border: 0; border-radius: 12px; color: inherit; background: transparent; padding: 11px 10px; text-align: left; cursor: pointer; }
+        #\${PANEL_ID} .better-codex-workflow-run:hover, #\${PANEL_ID} .better-codex-workflow-run.is-selected { background: var(--bc-hover); }
+        #\${PANEL_ID} .better-codex-workflow-run strong, #\${PANEL_ID} .better-codex-workflow-run span { display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+        #\${PANEL_ID} .better-codex-workflow-run strong { color: var(--bc-foreground); font-size: var(--bc-text-sm); }
+        #\${PANEL_ID} .better-codex-workflow-run span { margin-top: 4px; color: var(--bc-muted); font-size: var(--bc-text-caption); }
+        #\${PANEL_ID} .better-codex-workflow-empty { padding: 18px 15px; color: var(--bc-muted); font-size: var(--bc-text-sm); line-height: 1.5; }
+        #better-codex-workflow-dialog { width: min(560px,calc(100vw - 32px)); max-height: calc(100vh - 32px); border: 0; border-radius: 20px; color: var(--bc-foreground); background: var(--bc-surface); padding: 0; box-shadow: var(--bc-floating-shadow); font-family: var(--bc-font-ui); }
+        #better-codex-workflow-dialog::backdrop { background: var(--bc-scrim); backdrop-filter: blur(3px); }
+        #better-codex-workflow-dialog form { display: flex; max-height: calc(100vh - 32px); flex-direction: column; }
+        #better-codex-workflow-dialog header, #better-codex-workflow-dialog footer { display: flex; align-items: center; padding: 14px 16px; }
+        #better-codex-workflow-dialog header { justify-content: space-between; border-bottom: 0; }
+        #better-codex-workflow-dialog header strong { font-size: var(--bc-text-md); }
+        #better-codex-workflow-dialog header small { display: block; margin-top: 3px; color: var(--bc-muted); font-size: var(--bc-text-caption); }
+        #better-codex-workflow-dialog header button { display: inline-flex; width: 40px; height: 40px; align-items: center; justify-content: center; border: 0; border-radius: 10px; color: var(--bc-muted); background: transparent; cursor: pointer; }
+        #better-codex-workflow-dialog header button:hover { background: var(--bc-hover); }
+        #better-codex-workflow-dialog .better-codex-workflow-form { display: grid; min-height: 0; gap: 14px; overflow-y: auto; padding: 18px; }
+        #better-codex-workflow-dialog .better-codex-workflow-form-error { color: var(--bc-danger); font-size: var(--bc-text-sm); }
+        #better-codex-workflow-dialog .better-codex-workflow-confirm-copy { margin: 0; color: var(--bc-muted); font-size: var(--bc-text-sm); line-height: 1.65; }
+        #better-codex-workflow-dialog .better-codex-workflow-activation-agents { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; }
+        #better-codex-workflow-dialog .better-codex-workflow-activation-agent { display: flex; min-width: 0; align-items: center; gap: 10px; border-radius: 12px; background: var(--bc-page); padding: 10px; }
+        #better-codex-workflow-dialog .better-codex-workflow-activation-agent > span:last-child { min-width: 0; }
+        #better-codex-workflow-dialog .better-codex-workflow-activation-agent strong, #better-codex-workflow-dialog .better-codex-workflow-activation-agent small { display: block; }
+        #better-codex-workflow-dialog .better-codex-workflow-activation-agent strong { color: var(--bc-foreground); font-size: var(--bc-text-sm); }
+        #better-codex-workflow-dialog .better-codex-workflow-activation-agent small { margin-top: 2px; overflow: hidden; color: var(--bc-muted); font-size: var(--bc-text-caption); text-overflow: ellipsis; white-space: nowrap; }
+        #better-codex-workflow-dialog label { display: grid; gap: 6px; color: var(--bc-muted); font-size: var(--bc-text-sm); }
+        #better-codex-workflow-dialog input, #better-codex-workflow-dialog textarea, #better-codex-workflow-dialog select { box-sizing: border-box; width: 100%; border: 1px solid var(--bc-input); border-radius: 7px; color: var(--bc-foreground); background: var(--bc-surface); padding: 9px 10px; font: inherit; outline: none; }
+        #better-codex-workflow-dialog textarea { min-height: 132px; resize: vertical; }
+        #better-codex-workflow-dialog input:focus, #better-codex-workflow-dialog textarea:focus, #better-codex-workflow-dialog select:focus { border-color: var(--bc-ring); box-shadow: 0 0 0 2px color-mix(in srgb,var(--bc-ring) 20%,transparent); }
+        #better-codex-workflow-dialog footer { justify-content: flex-end; gap: 8px; border-top: 0; }
+        #better-codex-workflow-dialog footer button { min-height: 40px; border: 0; border-radius: 10px; color: var(--bc-foreground); background: var(--bc-hover); padding: 0 14px; font: inherit; cursor: pointer; transition: transform .14s; }
+        #better-codex-workflow-dialog footer button:active { transform: scale(.96); }
+        #better-codex-workflow-dialog footer button[type="submit"] { color: var(--bc-primary-foreground); background: var(--bc-primary); }
+        @media (max-width: 820px) { #\${PANEL_ID} .better-codex-workflow-layout { grid-template-columns: 1fr; } #\${PANEL_ID} .better-codex-workflow-aside { order: -1; } #\${PANEL_ID} .better-codex-workflow-detail-head { align-items: stretch; flex-direction: column; } #\${PANEL_ID} .better-codex-workflow-start { width: 100%; } #better-codex-workflow-dialog .better-codex-workflow-activation-agents { grid-template-columns: 1fr; } }
+        @media (prefers-reduced-motion: reduce) { #\${PANEL_ID} .better-codex-workflow-main, #\${PANEL_ID} .better-codex-workflow-chevron, #\${PANEL_ID} .better-codex-workflow-main.is-expanded .better-codex-workflow-detail, #\${PANEL_ID} .better-codex-workflow-start { animation: none; transition: none; } }
         #\${PANEL_ID} .better-codex-agent-grid { display: grid; max-width: 1080px; margin: 0 auto; grid-template-columns: repeat(auto-fill,minmax(280px,1fr)); gap: 12px; }
         #\${PANEL_ID} .better-codex-agent-card { display: flex; min-height: 214px; flex-direction: column; border: 1px solid var(--bc-border); border-radius: 12px; color: #27272a; background: #fff; padding: 16px; box-shadow: 0 1px 3px rgba(15,23,42,.08); transition: border-color .15s,transform .15s; }
         #\${PANEL_ID} .better-codex-agent-card:hover { border-color: #cfcfd4; }
@@ -1178,7 +1302,7 @@ export function injectionScript(port: number, accessToken: string, action: "inst
     function syncEntryIcon(button, surface) {
       const svg = button.querySelector("svg");
       if (svg) {
-        const definition = LUCIDE_ICONS[surface === "agents" ? "bot" : "issues"];
+        const definition = LUCIDE_ICONS[surface === "agents" ? "bot" : surface === "workflows" ? "layout" : "issues"];
         if (svg.getAttribute("viewBox") !== "0 0 24 24") svg.setAttribute("viewBox", "0 0 24 24");
         if (svg.getAttribute("fill") !== "none") svg.setAttribute("fill", "none");
         if (svg.getAttribute("stroke") !== "currentColor") svg.setAttribute("stroke", "currentColor");
@@ -1218,12 +1342,16 @@ export function injectionScript(port: number, accessToken: string, action: "inst
       syncEntryLabel(agentsEntry, "智能体", "管理智能体");
       syncEntryIcon(agentsEntry, "agents");
       if (agentsEntry.parentElement !== parent || agentsEntry.previousElementSibling !== entry) entry.after(agentsEntry);
-      const currentEntry = active && state.surface === "issues" ? entry : active && state.surface === "agents" ? agentsEntry : null;
-      for (const item of [entry, agentsEntry]) {
+      if (!workflowsEntry) workflowsEntry = createEntry("工作流", WORKFLOWS_ENTRY_ID, "打开工作流", "workflows");
+      syncEntryLabel(workflowsEntry, "工作流", "打开工作流");
+      syncEntryIcon(workflowsEntry, "workflows");
+      if (workflowsEntry.parentElement !== parent || workflowsEntry.previousElementSibling !== agentsEntry) agentsEntry.after(workflowsEntry);
+      const currentEntry = active && state.surface === "issues" ? entry : active && state.surface === "agents" ? agentsEntry : active && state.surface === "workflows" ? workflowsEntry : null;
+      for (const item of [entry, agentsEntry, workflowsEntry]) {
         if (item === currentEntry && item.getAttribute("aria-current") !== "page") item.setAttribute("aria-current", "page");
         if (item !== currentEntry && item.hasAttribute("aria-current")) item.removeAttribute("aria-current");
       }
-      return entry.isConnected && agentsEntry.isConnected;
+      return entry.isConnected && agentsEntry.isConnected && workflowsEntry.isConnected;
     }
 
     function findMount() {
@@ -1691,6 +1819,10 @@ export function injectionScript(port: number, accessToken: string, action: "inst
       if (value === "issue_session_starting") return t("原生会话正在创建，请稍后重试。");
       if (value === "manual_start_required") return t("当前为手动运行，请先点击“立即开始任务”。");
       if (value === "backlog_reply_blocked") return t("待规划中的 Issue 不会自动触发任务，请先移出待规划区。");
+      if (value === "workflow_not_activated") return t("工作流尚未激活。");
+      if (value === "workflow_agents_missing") return t("工作流所需 Agent 不完整，请重新激活。");
+      if (value === "agent_model_unavailable") return t("当前没有可用于创建 Agent 的模型。");
+      if (value === "workflow_agent_in_use") return t("该 Agent 正被已激活的工作流使用，无法删除。");
       return t(value);
     }
 
@@ -2775,8 +2907,158 @@ export function injectionScript(port: number, accessToken: string, action: "inst
         if (search) { search.focus(); search.setSelectionRange(search.value.length, search.value.length); }
       });
       agents.addEventListener("submit", onAgentSubmit);
-      section.append(toolbar, board, agents, recovery);
+      const workflows = document.createElement("main");
+      workflows.id = "better-codex-workflows";
+      workflows.className = "better-codex-workflows";
+      workflows.addEventListener("click", onWorkflowsClick);
+      section.append(toolbar, board, agents, workflows, recovery);
       return section;
+    }
+
+    function workflowStatus(issue) {
+      if (!issue) return { label: "等待中", icon: "circle" };
+      if (issue.status === "done") return { label: "已完成", icon: "check" };
+      if (issue.status === "backlog") return { label: "等待上游", icon: "dash" };
+      if (issue.status === "blocked") return { label: "已阻塞", icon: "close" };
+      if (issue.active_run_status || issue.session_active_turn_id) return { label: "工作中", icon: "refresh" };
+      if (issue.user_assigned) return { label: "等待确认", icon: "user" };
+      return { label: "待开始", icon: "circle" };
+    }
+
+    function workflowTemplateName(template) {
+      return state.locale === "en" ? template.name_en || template.name : template.name;
+    }
+
+    function workflowTemplateDescription(template) {
+      return state.locale === "en" ? template.description_en || template.description : template.description;
+    }
+
+    function renderWorkflows() {
+      const container = panel?.querySelector("#better-codex-workflows");
+      if (!container) return;
+      const template = state.workflowTemplates[0];
+      if (!template) {
+        container.innerHTML = '<div class="better-codex-workflow-empty">' + te("暂无工作流模板") + '</div>';
+        return;
+      }
+      const selectedRun = state.workflowRuns.find(run => run.id === state.selectedWorkflowRunId) || state.workflowRuns[0] || null;
+      if (selectedRun && state.selectedWorkflowRunId !== selectedRun.id) state.selectedWorkflowRunId = selectedRun.id;
+      const activation = state.workflowActivations.find(item => item.template_id === template.id);
+      const expanded = state.expandedWorkflowTemplateId === template.id;
+      const issueByNode = new Map((selectedRun?.nodes || []).map(node => [node.node_id, node.issue]));
+      const nodes = template.nodes.map((node, index) => {
+        const issue = issueByNode.get(node.id);
+        const status = workflowStatus(issue);
+        const action = issue?.session_thread_id || issue?.run_thread_id
+          ? '<button type="button" class="better-codex-workflow-node-state" data-workflow-thread="' + escapeHtml(issue.session_thread_id || issue.run_thread_id) + '">' + te("打开会话") + '</button>'
+          : issue ? '<button type="button" class="better-codex-workflow-node-state" data-workflow-issue="' + escapeHtml(issue.id) + '">' + te(status.label) + '</button>'
+          : '<span class="better-codex-workflow-node-state">' + te(index === 0 ? "就绪" : "等待中") + '</span>';
+        return '<div class="better-codex-workflow-node" data-status="' + escapeHtml(issue?.status || "template") + '"><span class="better-codex-workflow-node-mark">' + icon(status.icon) + '</span><span class="better-codex-workflow-node-copy"><strong>' + escapeHtml(node.title) + '</strong><span>' + escapeHtml(node.role + " · " + node.summary) + '</span></span>' + action + '</div>';
+      }).join("");
+      const runs = state.workflowRuns.map(run => {
+        const completed = run.nodes.filter(node => node.issue.status === "done").length;
+        return '<button type="button" class="better-codex-workflow-run' + (run.id === selectedRun?.id ? " is-selected" : "") + '" data-workflow-run="' + escapeHtml(run.id) + '"><strong>' + escapeHtml(run.title) + '</strong><span>' + completed + ' / ' + run.nodes.length + ' · ' + escapeHtml(t(run.status === "completed" ? "已完成" : "进行中")) + '</span></button>';
+      }).join("");
+      const statusChip = activation ? '<span class="is-active">' + te("已激活") + '</span>' : '<span>' + te("未激活") + '</span>';
+      const detailAction = activation
+        ? '<button class="better-codex-workflow-start" type="button" data-workflow-start>' + te("新建 Campaign") + '</button>'
+        : '<button class="better-codex-workflow-start" type="button" data-workflow-activate' + (state.mockup ? " disabled" : "") + '>' + te("激活工作流") + '</button>';
+      container.innerHTML = '<div class="better-codex-workflow-shell"><header class="better-codex-workflow-heading"><div><h1>' + te("工作流") + '</h1><p>' + te("用原生 Codex 会话完成跨 Agent 协作") + '</p></div></header><div class="better-codex-workflow-layout"><section class="better-codex-workflow-main' + (expanded ? " is-expanded" : "") + '"><button class="better-codex-workflow-template-head" type="button" data-workflow-template="' + escapeHtml(template.id) + '" aria-expanded="' + String(expanded) + '"><span class="better-codex-workflow-template-icon">' + icon("layout") + '</span><span class="better-codex-workflow-template-copy"><h2>' + escapeHtml(workflowTemplateName(template)) + '</h2><p>' + escapeHtml(workflowTemplateDescription(template)) + '</p><span class="better-codex-workflow-template-meta">' + statusChip + '<span>' + template.nodes.length + ' ' + te("个节点") + '</span><span>' + template.agents.length + ' ' + te("个专属 Agent") + '</span></span></span><span class="better-codex-workflow-chevron">' + icon("chevron") + '</span></button><div class="better-codex-workflow-detail"><div class="better-codex-workflow-detail-head"><span><strong>' + te(activation ? "工作流已就绪" : "激活后创建专属 Agent") + '</strong><span>' + te(activation ? "可以创建 Campaign，每个节点会使用已绑定的专属 Agent。" : "确认后会创建模板运行所需的 Agent，现有 Agent 不会被修改。") + '</span></span>' + detailAction + '</div><div class="better-codex-workflow-nodes">' + nodes + '</div></div></section><aside class="better-codex-workflow-aside"><h3>' + te("运行记录") + '</h3>' + (runs || '<div class="better-codex-workflow-empty">' + te(activation ? "还没有运行。创建 Campaign 后会启动第一个研究会话。" : "激活工作流后才能创建 Campaign。") + '</div>') + '</aside></div></div>';
+    }
+
+    function openWorkflowActivationDialog(template) {
+      document.getElementById("better-codex-workflow-dialog")?.remove();
+      const dialog = document.createElement("dialog");
+      dialog.id = "better-codex-workflow-dialog";
+      dialog.setAttribute(OWNED, "true");
+      const agents = template.agents.map(agent => '<div class="better-codex-workflow-activation-agent">' + agentAvatarMarkup(agent, "better-codex-agent-list-avatar") + '<span><strong>' + escapeHtml(state.locale === "en" ? agent.name_en || agent.name : agent.name) + '</strong><small>' + escapeHtml(agent.description) + '</small></span></div>').join("");
+      dialog.innerHTML = '<form><header><span><strong>' + te("激活工作流") + '</strong><small>' + escapeHtml(workflowTemplateName(template)) + '</small></span><button type="button" data-workflow-close aria-label="' + te("关闭") + '">' + icon("close") + '</button></header><div class="better-codex-workflow-form"><p class="better-codex-workflow-confirm-copy">' + te("这个工作流需要创建以下专属 Agent。它们会出现在智能体列表中，并由对应节点自动使用。") + '</p><div class="better-codex-workflow-activation-agents">' + agents + '</div><div class="better-codex-workflow-form-error" data-workflow-error hidden></div></div><footer><button type="button" data-workflow-close>' + te("取消") + '</button><button type="submit">' + te("确认并创建 Agent") + '</button></footer></form>';
+      const close = () => dialog.close();
+      dialog.querySelectorAll("[data-workflow-close]").forEach(button => button.addEventListener("click", close));
+      dialog.addEventListener("submit", event => {
+        event.preventDefault();
+        const submit = event.currentTarget.querySelector('button[type="submit"]');
+        const error = event.currentTarget.querySelector("[data-workflow-error]");
+        submit.disabled = true;
+        error.hidden = true;
+        void api("/api/workflows/" + encodeURIComponent(template.id) + "/activate", { method: "POST", body: "{}" }).then(async () => {
+          dialog.close();
+          await Promise.all([loadWorkflows(), loadAgents({ background: true })]);
+        }).catch(reason => {
+          error.textContent = errorLabel(reason);
+          error.hidden = false;
+        }).finally(() => { if (submit.isConnected) submit.disabled = false; });
+      });
+      dialog.addEventListener("close", () => dialog.remove(), { once: true });
+      bindModalDismiss(dialog, close);
+      document.body.appendChild(dialog);
+      dialog.showModal();
+    }
+
+    function openWorkflowStartDialog(template) {
+      document.getElementById("better-codex-workflow-dialog")?.remove();
+      const dialog = document.createElement("dialog");
+      dialog.id = "better-codex-workflow-dialog";
+      dialog.setAttribute(OWNED, "true");
+      const projectOptions = state.projects.map(project => '<option value="' + escapeHtml(project.id) + '"' + (project.id === state.projectId ? " selected" : "") + '>' + escapeHtml(projectLabel(project) || project.name) + '</option>').join("");
+      dialog.innerHTML = '<form><header><strong>' + escapeHtml(workflowTemplateName(template)) + '</strong><button type="button" data-workflow-close aria-label="' + te("关闭") + '">' + icon("close") + '</button></header><div class="better-codex-workflow-form"><label><span>' + te("Campaign 名称") + '</span><input name="title" maxlength="500" value="' + escapeHtml(t("新一轮内容 Campaign")) + '" required></label><label><span>' + te("项目") + '</span><select name="project_id" required>' + projectOptions + '</select></label><label><span>' + te("本轮输入") + '</span><textarea name="brief" maxlength="100000" placeholder="' + te("写下产品事实、目标受众、想解决的问题、已有素材和目标平台。") + '" required></textarea></label><div class="better-codex-workflow-form-error" data-workflow-error hidden></div></div><footer><button type="button" data-workflow-close>' + te("取消") + '</button><button type="submit">' + te("启动研究会话") + '</button></footer></form>';
+      const close = () => dialog.close();
+      dialog.querySelectorAll("[data-workflow-close]").forEach(button => button.addEventListener("click", close));
+      dialog.addEventListener("submit", event => {
+        event.preventDefault();
+        const form = event.target;
+        const submit = form.querySelector('button[type="submit"]');
+        submit.disabled = true;
+        const error = form.querySelector("[data-workflow-error]");
+        error.hidden = true;
+        void (async () => {
+          try {
+            const data = new FormData(form);
+            const projectId = String(data.get("project_id") || "");
+            const project = state.projects.find(item => item.id === projectId);
+            const run = await api("/api/workflow-runs", { method: "POST", body: JSON.stringify({ template_id: template.id, title: String(data.get("title") || ""), brief: String(data.get("brief") || ""), project_id: projectId, workspace_path: project?.workspace_path || "" }) });
+            state.selectedWorkflowRunId = run.id;
+            dialog.close();
+            await loadWorkflows();
+          } catch (reason) {
+            error.textContent = errorLabel(reason);
+            error.hidden = false;
+          } finally {
+            if (submit.isConnected) submit.disabled = false;
+          }
+        })();
+      });
+      dialog.addEventListener("close", () => dialog.remove(), { once: true });
+      bindModalDismiss(dialog, close);
+      document.body.appendChild(dialog);
+      dialog.showModal();
+      dialog.querySelector('textarea[name="brief"]')?.focus();
+    }
+
+    function onWorkflowsClick(event) {
+      const templateCard = event.target.closest("[data-workflow-template]");
+      if (templateCard) {
+        state.expandedWorkflowTemplateId = state.expandedWorkflowTemplateId === templateCard.dataset.workflowTemplate ? "" : templateCard.dataset.workflowTemplate;
+        renderWorkflows();
+        return;
+      }
+      const activate = event.target.closest("[data-workflow-activate]");
+      if (activate) return void openWorkflowActivationDialog(state.workflowTemplates[0]);
+      const start = event.target.closest("[data-workflow-start]");
+      if (start) return void openWorkflowStartDialog(state.workflowTemplates[0]);
+      const run = event.target.closest("[data-workflow-run]");
+      if (run) {
+        state.selectedWorkflowRunId = run.dataset.workflowRun;
+        renderWorkflows();
+        return;
+      }
+      const thread = event.target.closest("[data-workflow-thread]");
+      if (thread) return void perform(() => openThread(thread.dataset.workflowThread));
+      const issueButton = event.target.closest("[data-workflow-issue]");
+      if (!issueButton) return;
+      const selectedRun = state.workflowRuns.find(item => item.id === state.selectedWorkflowRunId) || state.workflowRuns[0];
+      const issue = selectedRun?.nodes.find(node => node.issue.id === issueButton.dataset.workflowIssue)?.issue;
+      if (issue) void perform(() => openEditor(issue));
     }
 
     function agentKey(agent) {
@@ -3623,6 +3905,7 @@ export function injectionScript(port: number, accessToken: string, action: "inst
       if (!panel) return;
       panel.dataset.surface = state.surface;
       renderAgents();
+      renderWorkflows();
       syncAutoDispatch();
       syncMockupUi();
       const runningCount = state.issues.filter(issue => issueExecutionRunning(issue) || issue.reply_status === "running").length;
@@ -3731,8 +4014,19 @@ export function injectionScript(port: number, accessToken: string, action: "inst
       render();
     }
 
+    async function loadWorkflows() {
+      const query = state.projectId ? "?project_id=" + encodeURIComponent(state.projectId) : "";
+      const result = await api("/api/workflows" + query);
+      state.workflowTemplates = result.templates || [];
+      state.workflowActivations = result.activations || [];
+      state.workflowRuns = result.runs || [];
+      if (!state.workflowRuns.some(run => run.id === state.selectedWorkflowRunId)) state.selectedWorkflowRunId = state.workflowRuns[0]?.id || "";
+      render();
+    }
+
     async function loadSurface(options = {}) {
       if (state.surface === "agents") await loadAgents(options);
+      else if (state.surface === "workflows") await loadWorkflows();
       else await loadIssues(options);
     }
 
@@ -5368,7 +5662,7 @@ export function injectionScript(port: number, accessToken: string, action: "inst
     function onClick(event) {
       if (!active || suppressAgentOutside) return;
       const target = event.target?.closest?.("button,a,[role='button']," + SELECTORS.threadRow);
-      if (!target || target === entry || target === agentsEntry || target.closest("#" + PANEL_ID) || target.closest("#better-codex-dialog") || target.closest("#better-codex-agent-dialog") || target.closest("#better-codex-avatar-picker")) return;
+      if (!target || target === entry || target === agentsEntry || target === workflowsEntry || target.closest("#" + PANEL_ID) || target.closest("#better-codex-dialog") || target.closest("#better-codex-agent-dialog") || target.closest("#better-codex-avatar-picker") || target.closest("#better-codex-workflow-dialog")) return;
       if (isSidebarNavigationTarget(target)) close({ resume: true });
       else if (target.closest(SELECTORS.sidebarNavigation)) scheduleRefresh();
     }
@@ -5386,7 +5680,7 @@ export function injectionScript(port: number, accessToken: string, action: "inst
       if (!betterCodexRoute) routeSuppressed = false;
       syncSessionHandoffFromHost();
       if (active && routeSeen && !betterCodexRoute) return close({ resume: true, suppressRoute: false });
-      if (!active && betterCodexRoute && !routeSuppressed && ["issues", "agents"].includes(resumeSurface)) return open(resumeSurface);
+      if (!active && betterCodexRoute && !routeSuppressed && ["issues", "agents", "workflows"].includes(resumeSurface)) return open(resumeSurface);
       if (active) mountPanel();
     }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -23,6 +23,7 @@ import { injectionScript } from "./dom.js";
 import { betterCodexWebHostCss, betterCodexWebHostHtml, betterCodexWebHostJavaScript } from "./web-host.js";
 import { SyncClient } from "./sync-client.js";
 import { removeSyncConfiguration } from "./sync-config.js";
+import { builtInWorkflowTemplates } from "./workflows.js";
 
 const accessToken = token();
 const mockupEnabled = !isSea() && !packagedBuild && process.argv.includes("--mockup");
@@ -1067,6 +1068,7 @@ export function startServer() {
         if (method === "DELETE" && path.length === 3) {
           const body = await readBody(request);
           if (store.hasActiveAgentSessionWork(profile.id)) throw new Error("agent_security_config_in_use");
+          if (store.workflowActivationForAgent(profile.id)) throw new Error("workflow_agent_in_use");
           store.deleteAgentProfile(profile.id, Number(body.version));
           syncAgentProfiles(store.listAgentProfiles());
           return sendJson(response, 200, { ok: true });
@@ -1145,6 +1147,43 @@ export function startServer() {
           ...issue,
           reply_status: store.getIssueReplyState(issue.id).status,
         })));
+      }
+      if (url.pathname === "/api/workflows" && method === "GET") {
+        return sendJson(response, 200, {
+          templates: builtInWorkflowTemplates,
+          activations: mockupEnabled ? [] : store.listWorkflowActivations(),
+          runs: mockupEnabled ? [] : store.listWorkflowRuns(url.searchParams.get("project_id") || undefined),
+        });
+      }
+      if (!mockupEnabled && path[0] === "api" && path[1] === "workflows" && path[2] && path[3] === "activate" && path.length === 4 && method === "POST") {
+        const profile = defaultAgentProfile();
+        const catalog = await readModelCatalog();
+        const model = catalog.find(item => item.id === profile.model) || catalog.find(item => item.isDefault) || catalog[0];
+        if (!model) throw new Error("agent_model_unavailable");
+        const reasoningEffort = model.supportedReasoningEfforts.some(item => item.value === profile.reasoning_effort) ? profile.reasoning_effort : model.defaultReasoningEffort;
+        const activation = store.activateWorkflow(decodeURIComponent(path[2]), {
+          model: model.id,
+          reasoning_effort: reasoningEffort,
+          sandbox_mode: profile.sandbox_mode,
+        });
+        syncAgentProfiles(store.listAgentProfiles());
+        return sendJson(response, 201, activation);
+      }
+      if (!mockupEnabled && url.pathname === "/api/workflow-runs" && method === "POST") {
+        const body = await readBody(request);
+        const run = store.createWorkflowRun({
+          templateId: cleanString(body.template_id, 200),
+          title: cleanString(body.title, 500),
+          brief: cleanString(body.brief, 100000),
+          projectId: cleanString(body.project_id, 200),
+          workspacePath: cleanString(body.workspace_path, 4096),
+        });
+        worker.startIssues(run.nodes.filter(node => node.issue.agent_enabled && node.issue.status === "todo").map(node => node.issue.id));
+        return sendJson(response, 201, run);
+      }
+      if (!mockupEnabled && path[0] === "api" && path[1] === "workflow-runs" && path[2] && path.length === 3 && method === "GET") {
+        const run = store.getWorkflowRun(decodeURIComponent(path[2]));
+        return run ? sendJson(response, 200, run) : sendJson(response, 404, { error: "workflow_run_not_found" });
       }
       if (path[0] === "api" && path[1] === "session-relay" && path[2] === "commands" && path[3] && path[4] === "checkpoint" && path.length === 5 && method === "POST") {
         const body = await readBody(request);
@@ -1235,7 +1274,9 @@ export function startServer() {
           const patch = parseIssuePatch(body);
           if ((issue.active_run_status || issue.session_active_turn_id || store.getIssueReplyState(issue.id).status === "running") && Object.keys(patch).some(key => key !== "reply_draft")) throw new Error("issue_execution_running");
           const updated = store.updateIssue(issue.id, version, patch);
+          if (updated.status === "done") worker.startIssues(store.advanceWorkflowForIssue(updated.id).filter(next => next.agent_enabled).map(next => next.id));
           if (store.isDispatchable(updated)) worker.wake();
+          else if (updated.status === "done") worker.wake();
           return sendJson(response, 200, updated);
         }
         if (method === "POST" && path[3] === "start" && path.length === 4) {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -103,6 +103,10 @@ export class IssueWorker {
     return true;
   }
 
+  startIssues(issueIds: string[]) {
+    for (const issueId of issueIds) this.startIssue(issueId);
+  }
+
   stopIssue(issueId: string) {
     this.store.dequeueManualStart(issueId);
     this.manualQueue.delete(issueId);
@@ -712,6 +716,7 @@ export class IssueWorker {
           const decision = code === 0 && existsSync(resultPath) ? parseSchedulerDecision(readFileSync(resultPath, "utf8")) : null;
           const schedulerError = timedOut ? "scheduler_timeout" : processError || (code === 0 ? decision ? undefined : "scheduler_invalid_output" : `scheduler_exit_${code ?? "unknown"}`);
           this.store.finalizeScheduler(claim.runId, claim.issue.id, executionSuccess, decision, schedulerError);
+          this.startIssues(this.store.advanceWorkflowForIssue(claim.issue.id).filter(issue => issue.agent_enabled).map(issue => issue.id));
         }
       }
       this.wake();

--- a/src/workflows.ts
+++ b/src/workflows.ts
@@ -1,0 +1,170 @@
+export type WorkflowNodeKind = "agent" | "gate";
+
+export type WorkflowNodeTemplate = {
+  id: string;
+  title: string;
+  role: string;
+  summary: string;
+  prompt: string;
+  kind: WorkflowNodeKind;
+  dependencies: string[];
+  agent?: string;
+};
+
+export type WorkflowAgentTemplate = {
+  id: string;
+  name: string;
+  name_en: string;
+  description: string;
+  instructions: string;
+  avatar: string;
+};
+
+export type WorkflowTemplate = {
+  id: string;
+  version: number;
+  name: string;
+  name_en: string;
+  description: string;
+  description_en: string;
+  category: string;
+  estimated_sessions: number;
+  agents: WorkflowAgentTemplate[];
+  nodes: WorkflowNodeTemplate[];
+};
+
+export const selfMediaWorkflowTemplate: WorkflowTemplate = {
+  id: "self-media-campaign",
+  version: 1,
+  name: "自媒体 Campaign",
+  name_en: "Creator Campaign",
+  description: "从事实研究、选题决策到多平台生产、独立审校、发布确认与复盘的 Codex 原生工作流。",
+  description_en: "A Codex-native creator workflow from research and topic approval through multi-channel production, review, publishing and retrospective.",
+  category: "自媒体",
+  estimated_sessions: 8,
+  agents: [
+    { id: "researcher", name: "内容研究", name_en: "Content Research", description: "核对事实、受众问题和趋势信号，建立可追溯的选题证据", instructions: "你是内容研究编辑。先核对工作区里的真实资料，再输出事实、受众问题、趋势信号、风险边界和选题候选。区分已证实事实与推断，不得虚构数据、案例或来源。", avatar: "icon:reviewer" },
+    { id: "lead_writer", name: "母内容主笔", name_en: "Lead Writer", description: "把确认后的选题写成统一叙事和事实口径的母内容", instructions: "你是母内容主笔。根据已确认选题和证据包完成可复用母稿，统一核心观点、事实引用、叙事结构、视觉方向和行动号召。所有重要主张必须能追溯到上游证据。", avatar: "icon:docs" },
+    { id: "short_editor", name: "短内容编辑", name_en: "Short-form Editor", description: "将母内容改编为微博、即刻、X 等平台短稿", instructions: "你是短内容编辑。保持母内容的事实边界，把它改编成适合短内容平台的钩子、主稿、精简稿、配图建议、标签和互动引导。不得制造母稿中不存在的结论。", avatar: "icon:sparkles" },
+    { id: "carousel_editor", name: "图文编辑", name_en: "Carousel Editor", description: "将母内容改编为公众号、小红书等结构化图文", instructions: "你是图文编辑。把母内容改编成标题、封面文案、逐页结构、正文、视觉提示、标签和互动问题，控制每页信息密度并保持事实口径一致。", avatar: "icon:layout" },
+    { id: "video_director", name: "视频编导", name_en: "Video Director", description: "将母内容改编为短视频口播、分镜和发布文案", instructions: "你是视频编导。把母内容改编成三秒钩子、完整口播、分镜节奏、画面与字幕提示、封面标题和发布文案，不得添加无法证明的数据或案例。", avatar: "icon:terminal" },
+    { id: "content_reviewer", name: "内容审校", name_en: "Content Reviewer", description: "独立检查事实、品牌表达、平台适配和发布风险", instructions: "你是独立内容审校。交叉检查各平台产物的事实可追溯性、前后口径、品牌表达、平台规范、敏感风险和素材缺口。明确列出阻断问题、修改建议和可发布版本。", avatar: "icon:shield" },
+    { id: "publishing_operator", name: "发布运营", name_en: "Publishing Operator", description: "整理最终文案、素材、平台参数和发布检查清单", instructions: "你是发布运营。根据人工确认结果整理各平台最终文案、素材路径、封面、标签、发布时间、发布前检查项和发布后数据回填项。不得自行执行外部发布。", avatar: "icon:wrench" },
+    { id: "growth_analyst", name: "内容复盘", name_en: "Growth Analyst", description: "根据真实发布结果沉淀经验、资产和下一轮实验", instructions: "你是内容增长分析师。根据真实发布回填总结有效钩子、平台差异、制作瓶颈、可复用资产、待观察指标和下一轮实验假设。数据不足时明确等待，不得伪造效果结论。", avatar: "icon:database" },
+  ],
+  nodes: [
+    {
+      id: "research",
+      title: "事实研究室",
+      role: "研究编辑",
+      summary: "收集产品事实、受众问题、趋势信号与可引用证据，形成选题候选。",
+      prompt: "核对输入材料和工作区里的真实证据，提炼受众问题、内容机会、可公开事实与风险边界。输出 Content Brief 和 Proof Pack，并给出 3 个按价值排序的选题候选。不要把未经验证的信息写成事实。",
+      kind: "agent",
+      dependencies: [],
+      agent: "researcher",
+    },
+    {
+      id: "topic_gate",
+      title: "选题确认",
+      role: "主理人",
+      summary: "人工确认主选题、核心观点和不应触碰的边界。",
+      prompt: "检查研究结果，确认本轮主选题、核心观点、目标平台和事实边界。需要调整时回到上游会话补充；确认后将此任务标记为已完成。",
+      kind: "gate",
+      dependencies: ["research"],
+    },
+    {
+      id: "master",
+      title: "母内容创作室",
+      role: "主笔编辑",
+      summary: "基于已确认选题写出完整母稿，统一叙事、证据和行动号召。",
+      prompt: "根据已确认的 Content Brief 与 Proof Pack 写出一份可复用母内容。包含标题方向、开场钩子、完整论证、事实引用、视觉素材建议、行动号召和平台改写约束。所有重要主张必须能追溯到上游证据。",
+      kind: "agent",
+      dependencies: ["topic_gate"],
+      agent: "lead_writer",
+    },
+    {
+      id: "short_post",
+      title: "短内容改编室",
+      role: "短内容编辑",
+      summary: "产出适合微博、即刻、X 等短内容平台的发布稿。",
+      prompt: "把母内容改编成短内容发布包。给出 3 个钩子、1 份主稿、1 份精简稿、配图建议、标签与评论区引导。保留事实边界，不制造母稿没有的结论。",
+      kind: "agent",
+      dependencies: ["master"],
+      agent: "short_editor",
+    },
+    {
+      id: "carousel",
+      title: "图文改编室",
+      role: "图文编辑",
+      summary: "产出适合公众号、小红书等图文平台的结构化发布包。",
+      prompt: "把母内容改编成图文发布包。输出标题备选、封面文案、逐页图文结构、正文、视觉提示、标签和互动问题。保证逐页信息密度合理，事实与母稿一致。",
+      kind: "agent",
+      dependencies: ["master"],
+      agent: "carousel_editor",
+    },
+    {
+      id: "video",
+      title: "视频改编室",
+      role: "视频编导",
+      summary: "产出适合抖音、视频号、B 站的口播和分镜方案。",
+      prompt: "把母内容改编成视频制作包。输出 3 秒钩子、完整口播、分镜节奏、画面与字幕提示、封面标题、发布文案和评论区引导。不要添加无法证明的数据或案例。",
+      kind: "agent",
+      dependencies: ["master"],
+      agent: "video_director",
+    },
+    {
+      id: "review",
+      title: "独立审校室",
+      role: "事实与品牌审校",
+      summary: "交叉检查各平台稿件的事实、表达、平台适配与发布风险。",
+      prompt: "独立审查所有平台产物。逐项检查事实可追溯性、前后口径、品牌表达、平台规范、敏感风险和素材缺口。输出阻断问题、建议修改和可发布版本清单；有阻断问题时明确要求返工。",
+      kind: "agent",
+      dependencies: ["short_post", "carousel", "video"],
+      agent: "content_reviewer",
+    },
+    {
+      id: "publish_gate",
+      title: "发布确认",
+      role: "主理人",
+      summary: "人工确认发布版本、平台、时间与外部操作范围。",
+      prompt: "检查独立审校结论，确认最终发布版本、平台、发布时间和账号。外部发布属于不可逆操作；只有明确同意后才将此任务标记为已完成。",
+      kind: "gate",
+      dependencies: ["review"],
+    },
+    {
+      id: "package",
+      title: "发布包整理室",
+      role: "发布运营",
+      summary: "整理最终文案、素材、平台参数和发布检查清单。",
+      prompt: "根据发布确认结果整理 Publication Package。按平台列出最终文案、素材路径、封面、标签、发布时间、发布前检查项和发布后需要回填的数据。不要自行执行外部发布。",
+      kind: "agent",
+      dependencies: ["publish_gate"],
+      agent: "publishing_operator",
+    },
+    {
+      id: "published_gate",
+      title: "发布结果回填",
+      role: "主理人",
+      summary: "人工完成发布并回填公开链接、发布时间和首轮数据。",
+      prompt: "完成外部发布后，在此任务中回填各平台公开链接、实际发布时间和可见状态。确认公开页面可访问后，将此任务标记为已完成。",
+      kind: "gate",
+      dependencies: ["package"],
+    },
+    {
+      id: "retrospective",
+      title: "Campaign 复盘室",
+      role: "增长分析",
+      summary: "基于发布结果沉淀本轮经验、复用资产与下一轮假设。",
+      prompt: "读取本轮全部产物与发布回填，完成 Campaign 复盘。总结有效钩子、平台差异、事实或制作瓶颈、可复用资产、待观察指标和下一轮 3 个实验假设。没有足够数据时明确等待窗口，不要伪造效果结论。",
+      kind: "agent",
+      dependencies: ["published_gate"],
+      agent: "growth_analyst",
+    },
+  ],
+};
+
+export const builtInWorkflowTemplates = [selfMediaWorkflowTemplate];
+
+export function workflowTemplate(id: string) {
+  return builtInWorkflowTemplates.find(template => template.id === id);
+}

--- a/test/core.test.ts
+++ b/test/core.test.ts
@@ -180,7 +180,7 @@ test("core workflow persists, orders status moves, and rejects stale writes", ()
     const restored = store.getIssue(first.id);
     assert.equal(restored?.status, "in_progress");
     assert.equal(restored?.thread_id, "local:thread-1");
-    assert.equal(store.health().schemaVersion, 6);
+    assert.equal(store.health().schemaVersion, 8);
     store.close();
   } finally {
     rmSync(target.directory, { recursive: true, force: true });
@@ -1067,7 +1067,7 @@ test("newer database schema is rejected without migration", () => {
   const target = temporaryDatabase();
   try {
     const future = new DatabaseSync(target.file);
-    future.exec("CREATE TABLE schema_migrations (version INTEGER PRIMARY KEY, applied_at TEXT NOT NULL); INSERT INTO schema_migrations VALUES (7, '2026-01-01T00:00:00.000Z')");
+    future.exec("CREATE TABLE schema_migrations (version INTEGER PRIMARY KEY, applied_at TEXT NOT NULL); INSERT INTO schema_migrations VALUES (9, '2026-01-01T00:00:00.000Z')");
     future.close();
     assert.throws(() => new Store(target.file), /database_schema_too_new/);
   } finally {
@@ -1111,7 +1111,7 @@ test("legacy database is backed up before migration", () => {
     legacy.close();
 
     const store = new Store(target.file);
-    assert.equal(store.health().schemaVersion, 6);
+    assert.equal(store.health().schemaVersion, 8);
     assert.ok(store.lastBackupPath);
     assert.ok(existsSync(store.lastBackupPath!));
     assert.equal(store.getProject("legacy")?.name, "Legacy");

--- a/test/dom.test.ts
+++ b/test/dom.test.ts
@@ -83,7 +83,7 @@ test("returning from a native settings route resumes the remembered Better Codex
   const refresh = source.slice(source.indexOf("function refresh()"), source.indexOf("function scheduleRefresh()"));
 
   assert.ok(refresh.includes("const resumeSurface = sessionStorage.getItem(RESUME_SURFACE_KEY)"));
-  assert.ok(refresh.includes('if (!active && betterCodexRoute && !routeSuppressed && ["issues", "agents"].includes(resumeSurface)) return open(resumeSurface)'));
+  assert.ok(refresh.includes('if (!active && betterCodexRoute && !routeSuppressed && ["issues", "agents", "workflows"].includes(resumeSurface)) return open(resumeSurface)'));
 });
 
 test("sidebar utility controls keep the Better Codex surface mounted", () => {
@@ -351,7 +351,8 @@ test("issue editor uses branded listboxes instead of native selects", () => {
   const source = injectionScript(4317, "test-token", "install");
   const css = betterCodexDesignSystemCss();
 
-  assert.doesNotMatch(source, /<select\b/);
+  const issueEditor = source.slice(source.indexOf("function openEditor(issue)"), source.indexOf("function closeFilterMenu()"));
+  assert.doesNotMatch(issueEditor, /<select\b/);
   assert.ok(source.includes('data-dialog-select-toggle="'));
   assert.ok(source.includes('data-dialog-select-option="'));
   assert.ok(source.includes('data-dialog-select-toggle="assignee"') || source.includes('dialogSelect("assignee"'));

--- a/test/gateway.test.ts
+++ b/test/gateway.test.ts
@@ -89,7 +89,7 @@ test("gateway completes the issue workflow and survives restart", async () => {
   try {
     await waitForGateway(port, gateway);
     const health = await (await fetch(`http://127.0.0.1:${port}/health`)).json() as { database: { schemaVersion: number } };
-    assert.equal(health.database.schemaVersion, 6);
+    assert.equal(health.database.schemaVersion, 8);
 
     const bootstrap = await (await request("/api/bootstrap")).json() as { projects: Array<{ external_id: string | null; created_at: string }>; agents: Array<{ id: string; name: string; is_default?: boolean }>; appearance: unknown };
     assert.equal(


### PR DESCRIPTION
Adds an activatable creator workflow with dedicated agents, native Codex conversation handoffs, approval gates, and a rounded workflow sidebar.\n\nThe workflow remains inactive by default. Activation creates and binds the required agents before campaigns can run.\n\nValidation: npm run release:beta -- 0.4.3-beta.5 --date 2026-08-12